### PR TITLE
Fix bug whereby marker would occasionally not be visible in single place routes

### DIFF
--- a/both/api/place-infos/place-infos.js
+++ b/both/api/place-infos/place-infos.js
@@ -12,7 +12,7 @@ if (Meteor.isClient) {
 }
 
 // Convert a given plain MongoDB document (not transformed) into a GeoJSON feature
-function convertToGeoJSONFeature(doc, coordinatesForDistance, locale) {
+PlaceInfos.convertToGeoJSONFeature = (doc, coordinatesForDistance, locale) => {
   const properties = {};
   Object.assign(properties, doc.properties, doc);
   if (coordinatesForDistance && properties.geometry && properties.geometry.coordinates) {
@@ -28,7 +28,7 @@ function convertToGeoJSONFeature(doc, coordinatesForDistance, locale) {
     geometry: properties.geometry,
     properties: _.omit(properties, 'geometry', 'originalData'),
   };
-}
+};
 
 PlaceInfos.wrapAPIResponse = ({ results, req, related, resultsCount }) => {
   // This is checked in buildSelectorAndOptions already, so no extra check here
@@ -44,7 +44,7 @@ PlaceInfos.wrapAPIResponse = ({ results, req, related, resultsCount }) => {
     featureCount: results.length,
     totalFeatureCount: resultsCount,
     related,
-    features: results.map(doc => convertToGeoJSONFeature(doc, coordinates, locale)),
+    features: results.map(doc => PlaceInfos.convertToGeoJSONFeature(doc, coordinates, locale)),
   };
 };
 

--- a/both/lib/build-feature-collection-from-array.js
+++ b/both/lib/build-feature-collection-from-array.js
@@ -1,0 +1,9 @@
+export default function buildFeatureCollectionFromArray(features) {
+  const featuresArray = [].concat(features).filter(Boolean);
+
+  return {
+    type: 'FeatureCollection',
+    featureCount: featuresArray.length,
+    features: featuresArray,
+  };
+}

--- a/client/pages/sources/show/overview/map.js
+++ b/client/pages/sources/show/overview/map.js
@@ -16,6 +16,8 @@ import 'leaflet.markercluster';
 import 'leaflet.markercluster/dist/MarkerCluster.css';
 import 'leaflet.markercluster/dist/MarkerCluster.Default.css';
 
+const PLACES_BATCH_SIZE = 5000;
+
 // Extend Leaflet-icon to support colors and category-images
 L.AccessibilityIcon = L.Icon.extend({
   options: {
@@ -136,16 +138,15 @@ function mergeFeatureCollections(featureCollections) {
 }
 
 async function getPlaces(limit, onProgress = () => {}) {
-  const batchSize = 5000;
-  const firstResponseData = (await getPlacesBatch(0, batchSize)).data;
+  const firstResponseData = (await getPlacesBatch(0, PLACES_BATCH_SIZE)).data;
   const numberOfPlacesToFetch = Math.min(firstResponseData.totalFeatureCount, limit);
   let progress = firstResponseData.featureCount;
   const sendProgress = () => onProgress({ percentage: 100 * progress / numberOfPlacesToFetch });
-  if (numberOfPlacesToFetch > batchSize) {
+  if (numberOfPlacesToFetch > PLACES_BATCH_SIZE) {
     const pageIndexes =
-      Array.from({ length: (numberOfPlacesToFetch / batchSize) - 1 }, (v, k) => k + 1);
+      Array.from({ length: (numberOfPlacesToFetch / PLACES_BATCH_SIZE) - 1 }, (v, k) => k + 1);
     const promises = pageIndexes.map(index =>
-      getPlacesBatch(index * batchSize, batchSize).then(response => {
+      getPlacesBatch(index * PLACES_BATCH_SIZE, PLACES_BATCH_SIZE).then(response => {
         progress += response.data.featureCount;
         sendProgress();
         return response.data;

--- a/client/pages/sources/show/overview/map.js
+++ b/client/pages/sources/show/overview/map.js
@@ -210,25 +210,30 @@ Template.sources_show_page_map.onRendered(function sourcesShowPageOnRendered() {
 
   this.autorun(() => {
     if (!Meteor.userId()) { return; }
+
     FlowRouter.watchPathChange();
     const limit = FlowRouter.getQueryParam('limit') || 5000;
-    if (!this.currentLimit || limit > this.currentLimit) {
-      this.currentLimit = limit;
-      loadPlaces(limit, progress => instance.loadProgress.set(progress))
-        .then(
-          (places) => {
-            instance.isClustering.set(true);
-            markers = showPlacesOnMap(map, places);
-            instance.isClustering.set(false);
-            instance.isLoading.set(false);
-          },
-          (error) => {
-            instance.loadError.set(error);
-            instance.isLoading.set(false);
-          }
-        );
-      FlowRouter.setQueryParams({ limit });
+
+    if (this.currentLimit && limit <= this.currentLimit) {
+      return;
     }
+
+    this.currentLimit = limit;
+    loadPlaces(limit, progress => instance.loadProgress.set(progress))
+      .then(
+        (places) => {
+          instance.isClustering.set(true);
+          markers = showPlacesOnMap(map, places);
+          instance.isClustering.set(false);
+          instance.isLoading.set(false);
+        },
+        (error) => {
+          instance.loadError.set(error);
+          instance.isLoading.set(false);
+        }
+      );
+    FlowRouter.setQueryParams({ limit });
   });
+
   this.autorun(() => centerOnCurrentPlace(map));
 });


### PR DESCRIPTION
This PR makes sure that a single `placeInfo` is displayed on the map when the route contains a `placeInfoId`.


Fixes https://trello.com/c/6E4Agmqf/324-ensure-single-poi-link-works-always (contains reproduction steps)