### PR TITLE
Get places in batches in overview

### DIFF
--- a/client/pages/sources/show/overview/map.js
+++ b/client/pages/sources/show/overview/map.js
@@ -80,7 +80,6 @@ function filterShownMarkers(featureCollection) {
 function showPlacesOnMap(markerClusterGroup, map, unfilteredFeatureCollection) {
   const featureCollection = filterShownMarkers(unfilteredFeatureCollection);
 
-  // console.log('Adding', featureCollection.features.length, 'new places to map...');
   if (featureCollection.features && featureCollection.features.length) {
     const geojsonLayer = new L.geoJson(featureCollection, { // eslint-disable-line new-cap
       pointToLayer(feature, latlng) {
@@ -125,7 +124,6 @@ function showPlacesOnMap(markerClusterGroup, map, unfilteredFeatureCollection) {
 }
 
 async function getPlacesBatch(skip, limit, sendProgress) {
-  // console.log('Get places batch, skip', skip, 'limit', limit);
   const hashedToken = await getApiUserToken();
   const options = {
     params: { skip, limit, includeSourceIds: FlowRouter.getParam('_id') },
@@ -160,7 +158,6 @@ async function getPlaces(limit, onProgress = () => {}) {
   const firstResponseData = (await getPlacesBatch(0, PLACES_BATCH_SIZE, sendProgress)).data;
   progress = firstResponseData.featureCount;
   numberOfPlacesToFetch = Math.min(firstResponseData.totalFeatureCount, limit);
-  // console.log('We have to fetch', numberOfPlacesToFetch, 'places.');
 
   // Allow only 3 running requests at the same time. Without this, all requests
   // would be started at the same time leading to timeouts.
@@ -217,7 +214,6 @@ Template.sources_show_page_map.onRendered(function sourcesShowPageOnRendered() {
   let currentSourceId = null;
 
   function removeMarkers() {
-    // console.log('Removing marker clusters.');
     Object.keys(idsToShownMarkers).forEach(key => delete idsToShownMarkers[key]);
     if (markerClusterGroup) {
       map.removeLayer(markerClusterGroup);
@@ -226,7 +222,6 @@ Template.sources_show_page_map.onRendered(function sourcesShowPageOnRendered() {
   }
 
   async function loadPlaces(limit, onProgress) {
-    // console.log('Loading places...');
     instance.isLoading.set(true);
     instance.loadError.set(null);
     instance.loadProgress.set({});
@@ -250,7 +245,6 @@ Template.sources_show_page_map.onRendered(function sourcesShowPageOnRendered() {
     let placesPromise;
 
     if (isShowingASinglePlace) {
-      // console.log('Showing a single place...');
       const placeInfoId = FlowRouter.getParam('placeInfoId');
       const doc = PlaceInfos.findOne(placeInfoId);
       const place = doc && PlaceInfos.convertToGeoJSONFeature(doc);

--- a/client/pages/sources/show/overview/map.js
+++ b/client/pages/sources/show/overview/map.js
@@ -10,6 +10,7 @@ import { _ } from 'meteor/stevezhu:lodash';
 import { PlaceInfos } from '/both/api/place-infos/place-infos.js';
 import { getCurrentPlaceInfo } from './get-current-place-info';
 import { getApiUserToken } from '/client/lib/api-tokens';
+import PromisePool from 'es6-promise-pool';
 import buildFeatureCollectionFromArray from '/both/lib/build-feature-collection-from-array';
 
 import 'leaflet';
@@ -18,8 +19,9 @@ import 'leaflet.markercluster';
 import 'leaflet.markercluster/dist/MarkerCluster.css';
 import 'leaflet.markercluster/dist/MarkerCluster.Default.css';
 
-const PLACES_BATCH_SIZE = 5000;
-const DEFAULT_NUMBER_OF_PLACES_FETCHED = 5000;
+const PLACES_BATCH_SIZE = 2000;
+const CONCURRENCY_LIMIT = 3;
+const DEFAULT_NUMBER_OF_PLACES_FETCHED = 10000;
 
 // Extend Leaflet-icon to support colors and category-images
 L.AccessibilityIcon = L.Icon.extend({
@@ -61,36 +63,53 @@ function getColorForWheelchairAccessiblity(placeData) {
 function centerOnCurrentPlace(map) {
   const place = getCurrentPlaceInfo();
   if (place) {
-    map.setView(place.geometry.coordinates.reverse(), 16);
+    map.setView(place.geometry.coordinates.reverse(), 18);
   }
 }
 
-function showPlacesOnMap(map, geoMarkerData) {
-  const geojsonLayer = new L.geoJson(geoMarkerData, { // eslint-disable-line new-cap
-    pointToLayer(feature, latlng) {
-      const categoryIconName = _.get(feature, 'properties.category') || 'place';
-      const color = getColorForWheelchairAccessiblity(feature);
+const idsToShownMarkers = {};
 
-      const acIcon = new L.AccessibilityIcon({
-        iconUrl: `/icons/categories/${categoryIconName}.png`,
-        className: `ac-marker ${color}`,
-        // iconSize: [27, 27],
-      });
-      const marker = L.marker(latlng, { icon: acIcon });
-      marker.on('click', () => {
-        FlowRouter.go('placeInfos.show', {
-          _id: FlowRouter.getParam('_id'),
-          limit: FlowRouter.getParam('limit'),
-          placeInfoId: feature.properties._id,
+function filterShownMarkers(featureCollection) {
+  const result = {};
+  result.features = featureCollection.features
+    .filter(feature => !idsToShownMarkers[feature.properties._id]);
+  result.featureCount = result.features.length;
+  return result;
+}
+
+function showPlacesOnMap(markerClusterGroup, map, unfilteredFeatureCollection) {
+  const featureCollection = filterShownMarkers(unfilteredFeatureCollection);
+
+  // console.log('Adding', featureCollection.features.length, 'new places to map...');
+  if (featureCollection.features && featureCollection.features.length) {
+    const geojsonLayer = new L.geoJson(featureCollection, { // eslint-disable-line new-cap
+      pointToLayer(feature, latlng) {
+        const id = feature.properties._id;
+        if (idsToShownMarkers[id]) {
+          return idsToShownMarkers[id];
+        }
+        const categoryIconName = _.get(feature, 'properties.category') || 'place';
+        const color = getColorForWheelchairAccessiblity(feature);
+
+        const acIcon = new L.AccessibilityIcon({
+          iconUrl: `/icons/categories/${categoryIconName}.png`,
+          className: `ac-marker ${color}`,
+          // iconSize: [27, 27],
         });
-      });
+        const marker = L.marker(latlng, { icon: acIcon });
+        marker.on('click', () => {
+          FlowRouter.go('placeInfos.show', {
+            _id: FlowRouter.getParam('_id'),
+            limit: FlowRouter.getParam('limit'),
+            placeInfoId: feature.properties._id,
+          });
+        });
+        idsToShownMarkers[id] = marker;
+        return marker;
+      },
+    });
 
-      return marker;
-    },
-  });
-
-  if (geoMarkerData.features && geoMarkerData.features.length) {
-    const markers = L.markerClusterGroup({
+    const markers = markerClusterGroup || L.markerClusterGroup({
       polygonOptions: {
         color: '#08c',
         weight: 1,
@@ -105,18 +124,12 @@ function showPlacesOnMap(map, geoMarkerData) {
   return null;
 }
 
-async function getPlacesBatch(skip, limit) {
+async function getPlacesBatch(skip, limit, sendProgress) {
+  // console.log('Get places batch, skip', skip, 'limit', limit);
   const hashedToken = await getApiUserToken();
   const options = {
-    params: {
-      skip,
-      limit,
-      includeSourceIds: FlowRouter.getParam('_id'),
-    },
-    headers: {
-      Accept: 'application/json',
-      'X-User-Token': hashedToken,
-    },
+    params: { skip, limit, includeSourceIds: FlowRouter.getParam('_id') },
+    headers: { Accept: 'application/json', 'X-User-Token': hashedToken },
   };
 
   return new Promise((resolve, reject) => {
@@ -124,42 +137,43 @@ async function getPlacesBatch(skip, limit) {
       if (error) {
         reject(error);
       } else {
+        sendProgress(response.data);
         resolve(response);
       }
     });
   });
 }
 
-function mergeFeatureCollections(featureCollections) {
-  if (!featureCollections || featureCollections.length === 0) {
-    return { type: 'FeatureCollection', features: [] };
-  }
-  const result = featureCollections[0];
-  featureCollections.slice(1)
-    .forEach(c => { result.features = result.features.concat(c.features); });
-  return result;
-}
-
 async function getPlaces(limit, onProgress = () => {}) {
-  const firstResponseData = (await getPlacesBatch(0, PLACES_BATCH_SIZE)).data;
-  const numberOfPlacesToFetch = Math.min(firstResponseData.totalFeatureCount, limit);
-  let progress = firstResponseData.featureCount;
-  const sendProgress = () => onProgress({ percentage: 100 * progress / numberOfPlacesToFetch });
-  if (numberOfPlacesToFetch > PLACES_BATCH_SIZE) {
-    const pageIndexes =
-      Array.from({ length: (numberOfPlacesToFetch / PLACES_BATCH_SIZE) - 1 }, (v, k) => k + 1);
-    const promises = pageIndexes.map(index =>
-      getPlacesBatch(index * PLACES_BATCH_SIZE, PLACES_BATCH_SIZE).then(response => {
-        progress += response.data.featureCount;
-        sendProgress();
-        return response.data;
-      })
-    );
-    const responses = await Promise.all(promises);
-    const result = mergeFeatureCollections([firstResponseData].concat(responses));
-    return result;
+  let progress = 0;
+  let numberOfPlacesToFetch = 0;
+  const sendProgress = (responseData) => {
+    progress += responseData.featureCount;
+    onProgress({
+      featureCollection: responseData,
+      percentage: numberOfPlacesToFetch ? 100 * progress / numberOfPlacesToFetch : 0,
+    });
+    return responseData;
+  };
+
+  // The first batch's response contains the total number of features to fetch.
+  const firstResponseData = (await getPlacesBatch(0, PLACES_BATCH_SIZE, sendProgress)).data;
+  progress = firstResponseData.featureCount;
+  numberOfPlacesToFetch = Math.min(firstResponseData.totalFeatureCount, limit);
+  // console.log('We have to fetch', numberOfPlacesToFetch, 'places.');
+
+  // Allow only 3 running requests at the same time. Without this, all requests
+  // would be started at the same time leading to timeouts.
+  function *generatePromises() {
+    if (numberOfPlacesToFetch <= PLACES_BATCH_SIZE) {
+      return;
+    }
+    for (let i = 1; i < (numberOfPlacesToFetch / PLACES_BATCH_SIZE); i++) {
+      yield getPlacesBatch(i * PLACES_BATCH_SIZE, PLACES_BATCH_SIZE, sendProgress);
+    }
   }
-  return firstResponseData;
+  const pool = new PromisePool(generatePromises(), CONCURRENCY_LIMIT);
+  return pool.start();
 }
 
 Template.sources_show_page_map.onCreated(function created() {
@@ -169,7 +183,7 @@ Template.sources_show_page_map.onCreated(function created() {
   this.isClustering = new ReactiveVar();
 });
 
-['isLoading', 'loadError', 'loadProgress', 'isClustering'].forEach(helper =>
+['isLoading', 'loadError', 'loadProgress'].forEach(helper =>
   Template.sources_show_page_map.helpers({
     [helper]() { return Template.instance()[helper].get(); },
   })
@@ -194,25 +208,39 @@ function initializeMap(instance) {
   return map;
 }
 
+let markerClusterGroup = null;
+
 Template.sources_show_page_map.onRendered(function sourcesShowPageOnRendered() {
   const map = initializeMap(this);
 
-  let markers = null;
   const instance = this;
+  let currentSourceId = null;
+
+  function removeMarkers() {
+    // console.log('Removing marker clusters.');
+    Object.keys(idsToShownMarkers).forEach(key => delete idsToShownMarkers[key]);
+    if (markerClusterGroup) {
+      map.removeLayer(markerClusterGroup);
+      markerClusterGroup = null;
+    }
+  }
 
   async function loadPlaces(limit, onProgress) {
+    // console.log('Loading places...');
     instance.isLoading.set(true);
     instance.loadError.set(null);
     instance.loadProgress.set({});
-    if (markers) {
-      map.removeLayer(markers);
-      markers = null;
-    }
     return getPlaces(limit, onProgress);
   }
 
   this.autorun(() => {
     if (!Meteor.userId()) { return; }
+
+    const newSourceId = FlowRouter.getParam('_id');
+    if (newSourceId !== currentSourceId) {
+      removeMarkers();
+      currentSourceId = newSourceId;
+    }
 
     FlowRouter.watchPathChange();
     const limit = Number(FlowRouter.getQueryParam('limit')) || DEFAULT_NUMBER_OF_PLACES_FETCHED;
@@ -222,13 +250,13 @@ Template.sources_show_page_map.onRendered(function sourcesShowPageOnRendered() {
     let placesPromise;
 
     if (isShowingASinglePlace) {
+      // console.log('Showing a single place...');
       const placeInfoId = FlowRouter.getParam('placeInfoId');
-      const doc = PlaceInfos.findOne({
-        _id: placeInfoId,
-      });
+      const doc = PlaceInfos.findOne(placeInfoId);
       const place = doc && PlaceInfos.convertToGeoJSONFeature(doc);
       const featureCollection = buildFeatureCollectionFromArray([place]);
-      placesPromise = Promise.resolve(featureCollection);
+      markerClusterGroup = showPlacesOnMap(markerClusterGroup, map, featureCollection);
+      placesPromise = Promise.resolve();
     } else {
       const isDisplayingFewerMarkersThanBefore = this.currentLimit && limit <= this.currentLimit;
       if (isDisplayingFewerMarkersThanBefore) {
@@ -236,15 +264,16 @@ Template.sources_show_page_map.onRendered(function sourcesShowPageOnRendered() {
       }
 
       this.currentLimit = limit;
-      placesPromise = loadPlaces(limit, progress => instance.loadProgress.set(progress));
+
+      placesPromise = loadPlaces(limit, ({ featureCollection, percentage }) => {
+        markerClusterGroup = showPlacesOnMap(markerClusterGroup, map, featureCollection);
+        instance.loadProgress.set({ percentage });
+      });
     }
 
     placesPromise
       .then(
-        (places) => {
-          instance.isClustering.set(true);
-          markers = showPlacesOnMap(map, places);
-          instance.isClustering.set(false);
+        () => {
           instance.isLoading.set(false);
         },
         (error) => {

--- a/client/pages/sources/show/overview/map.js
+++ b/client/pages/sources/show/overview/map.js
@@ -80,47 +80,48 @@ function filterShownMarkers(featureCollection) {
 function showPlacesOnMap(markerClusterGroup, map, unfilteredFeatureCollection) {
   const featureCollection = filterShownMarkers(unfilteredFeatureCollection);
 
-  if (featureCollection.features && featureCollection.features.length) {
-    const geojsonLayer = new L.geoJson(featureCollection, { // eslint-disable-line new-cap
-      pointToLayer(feature, latlng) {
-        const id = feature.properties._id;
-        if (idsToShownMarkers[id]) {
-          return idsToShownMarkers[id];
-        }
-        const categoryIconName = _.get(feature, 'properties.category') || 'place';
-        const color = getColorForWheelchairAccessiblity(feature);
-
-        const acIcon = new L.AccessibilityIcon({
-          iconUrl: `/icons/categories/${categoryIconName}.png`,
-          className: `ac-marker ${color}`,
-          // iconSize: [27, 27],
-        });
-        const marker = L.marker(latlng, { icon: acIcon });
-        marker.on('click', () => {
-          FlowRouter.go('placeInfos.show', {
-            _id: FlowRouter.getParam('_id'),
-            limit: FlowRouter.getParam('limit'),
-            placeInfoId: feature.properties._id,
-          });
-        });
-        idsToShownMarkers[id] = marker;
-        return marker;
-      },
-    });
-
-    const markers = markerClusterGroup || L.markerClusterGroup({
-      polygonOptions: {
-        color: '#08c',
-        weight: 1,
-      },
-    });
-    markers.addLayer(geojsonLayer, { chunkedLoading: true });
-    map.addLayer(markers);
-    map.fitBounds(markers.getBounds().pad(0.02));
-    centerOnCurrentPlace(map);
-    return markers;
+  if (!featureCollection.features || !featureCollection.features.length) {
+    return null;
   }
-  return null;
+
+  const geojsonLayer = new L.geoJson(featureCollection, { // eslint-disable-line new-cap
+    pointToLayer(feature, latlng) {
+      const id = feature.properties._id;
+      if (idsToShownMarkers[id]) {
+        return idsToShownMarkers[id];
+      }
+      const categoryIconName = _.get(feature, 'properties.category') || 'place';
+      const color = getColorForWheelchairAccessiblity(feature);
+
+      const acIcon = new L.AccessibilityIcon({
+        iconUrl: `/icons/categories/${categoryIconName}.png`,
+        className: `ac-marker ${color}`,
+        // iconSize: [27, 27],
+      });
+      const marker = L.marker(latlng, { icon: acIcon });
+      marker.on('click', () => {
+        FlowRouter.go('placeInfos.show', {
+          _id: FlowRouter.getParam('_id'),
+          limit: FlowRouter.getParam('limit'),
+          placeInfoId: feature.properties._id,
+        });
+      });
+      idsToShownMarkers[id] = marker;
+      return marker;
+    },
+  });
+
+  const markers = markerClusterGroup || L.markerClusterGroup({
+    polygonOptions: {
+      color: '#08c',
+      weight: 1,
+    },
+  });
+  markers.addLayer(geojsonLayer, { chunkedLoading: true });
+  map.addLayer(markers);
+  map.fitBounds(markers.getBounds().pad(0.02));
+  centerOnCurrentPlace(map);
+  return markers;
 }
 
 async function getPlacesBatch(skip, limit, sendProgress) {

--- a/client/stylesheets/base.less
+++ b/client/stylesheets/base.less
@@ -48,6 +48,10 @@ h5 {
 h6 {
 }
 
+p {
+  .font-s3;
+}
+
 sub,
 sup {
   font-size: .8em;

--- a/client/stylesheets/components.import.less
+++ b/client/stylesheets/components.import.less
@@ -54,23 +54,11 @@ button.btn-primary {
 
 div.markdown {
   max-width:50em;
-  dd, dl, dt, li, ol, ul, fieldset, form, label, legend, caption, th, td, p, blockquote, {
-    line-height: 1.5;
-  }
   p {
     margin-bottom:0.5em;
   }
   h1,h2,h3,h4 {
     maring-top:1em;
-  }
-  ol, ul {
-    margin-left: 2em;
-  }
-  ol {
-    list-style-type: decimal;
-  }
-  ul {
-    list-style-type: circle;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "csv-stream": "^0.1.3",
     "csvstream": "^1.1.0",
     "d3": "^4.5.0",
+    "es6-promise-pool": "^2.4.4",
     "event-stream": "^3.3.4",
     "faker": "^3.1.0",
     "fast-csv": "^2.3.0",


### PR DESCRIPTION
This fetches places in batches of 2000 from the API, while only allowing 3 running requests at the same time, fixing timeouts on the production servers.

When a new batch of places is arriving, it’s directly clustered with leaflet (a CPU-expensive op). This way, clustering runs in parallel with the requests.