### PR TITLE
Refactor: Cache source place info counts after each import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 settings/*
 !settings/*-example.json
+.DS_Store
+.meteor/local/

--- a/both/api/organizations/organizations.js
+++ b/both/api/organizations/organizations.js
@@ -142,7 +142,7 @@ Organizations.helpers({
   },
   getSources() {
     const sources = Sources.find({ organizationId: this._id }).fetch();
-    return _.sortBy(_.sortBy(sources, (s) => s.placeInfoCount && -s.placeInfoCount()), 'isDraft');
+    return _.sortBy(_.sortBy(sources, (s) => -s.placeInfoCount), 'isDraft');
   },
   getApps() {
     return Apps.find({ organizationId: this._id });

--- a/both/api/source-imports/client/stats.js
+++ b/both/api/source-imports/client/stats.js
@@ -30,7 +30,7 @@ SourceImports.helpers({
     if (!source) {
       return [];
     }
-    const totalCount = this.getSource().placeInfoCount();
+    const totalCount = this.getSource().placeInfoCount;
     const typeNamesToCounts =
       _.get(attributeDistribution, 'properties.properties.accessibility.accessibleWith');
     return Object.keys(typeNamesToCounts)

--- a/both/api/source-imports/server/privileges.js
+++ b/both/api/source-imports/server/privileges.js
@@ -20,6 +20,7 @@ SourceImports.publicFields = {
   numberOfPlacesModified: 1,
   numberOfPlacesRemoved: 1,
   numberOfPlacesUnchanged: 1,
+  placeInfoCountAfterImport: 1,
   error: 1,
 };
 

--- a/both/api/source-imports/server/stats.js
+++ b/both/api/source-imports/server/stats.js
@@ -1,6 +1,7 @@
-import util from 'util';
+// import util from 'util';
 import { PlaceInfos } from '/both/api/place-infos/place-infos.js';
 import { SourceImports } from '/both/api/source-imports/source-imports.js';
+import { Sources } from '/both/api/sources/sources.js';
 import { _ } from 'lodash';
 
 const attributeBlacklist = {
@@ -50,8 +51,8 @@ SourceImports.helpers({
       { transform: null }
     );
 
-    const numberOfPlaces = placeInfos.count();
-    console.log('Analysing', numberOfPlaces, 'PoIs...');
+    const placeInfoCount = placeInfos.count();
+    console.log('Analysing', placeInfoCount, 'PoIs...');
     const startDate = new Date();
 
     placeInfos.forEach(placeInfo => {
@@ -61,8 +62,8 @@ SourceImports.helpers({
     const seconds = 0.001 * (new Date() - startDate);
     console.log(
       'Analysed',
-      numberOfPlaces,
-      `PoIs in ${seconds} seconds (${numberOfPlaces / seconds} PoIs/second).`
+      placeInfoCount,
+      `PoIs in ${seconds} seconds (${placeInfoCount / seconds} PoIs/second).`
     );
 
     // Uncomment this for debugging
@@ -73,9 +74,11 @@ SourceImports.helpers({
     SourceImports.update(this._id, {
       $set: {
         attributeDistribution: JSON.stringify(attributeDistribution),
+        placeInfoCountAfterImport: placeInfoCount,
       },
     });
 
+    Sources.update(this.sourceId, { $set: { placeInfoCount } });
     return attributeDistribution;
   },
 });

--- a/both/api/sources/server/methods.js
+++ b/both/api/sources/server/methods.js
@@ -18,6 +18,13 @@ Meteor.methods({
     return PlaceInfos.find({ 'properties.sourceId': sourceId }, { limit: limitCount }).fetch();
   },
 
+  cachePlaceCountForSource(sourceId) {
+    check(sourceId, String);
+    checkExistenceAndVisibilityForSourceId(this.userId, sourceId);
+    const placeInfoCount = PlaceInfos.find({ 'properties.sourceId': sourceId }).count();
+    Sources.update(sourceId, { $set: { placeInfoCount } });
+  },
+
   updateDataURLForSource(sourceId, url) {
     check(sourceId, String);
     check(url, String);

--- a/both/api/sources/server/privileges.js
+++ b/both/api/sources/server/privileges.js
@@ -28,6 +28,7 @@ Sources.publicFields = {
   isFreelyAccessible: 1,
   accessRestrictedTo: 1,
   hasRunningImport: 1,
+  placeInfoCount: 1,
 };
 
 Sources.privateFields = {

--- a/both/api/sources/sources.js
+++ b/both/api/sources/sources.js
@@ -117,6 +117,16 @@ Sources.schema = new SimpleSchema({
       },
     },
   },
+  placeInfoCount: {
+    type: Number,
+    defaultValue: 0,
+    optional: true,
+    autoform: {
+      afFieldInput: {
+        type: 'hidden',
+      },
+    },
+  },
 });
 
 Sources.attachSchema(Sources.schema);
@@ -167,16 +177,6 @@ Sources.helpers({
       .find(i => (i.isFinished() && !i.hasError() && !i.isAborted()));
   },
 });
-
-if (Meteor.isClient) {
-  export const PlaceInfoCounts = new Meteor.Collection('sourcesPlaceInfoCounts');
-  Sources.helpers({
-    placeInfoCount() {
-      const countDoc = PlaceInfoCounts.findOne(this._id);
-      return countDoc && countDoc.count;
-    },
-  });
-}
 
 if (Meteor.isServer) {
   SourceImports._ensureIndex({ licenseId: 1 });

--- a/client/components/source/source.html
+++ b/client/components/source/source.html
@@ -15,9 +15,7 @@
             <span class='subtle'>by {{getOrganization.name}}</span>
           {{/if}}
 
-          {{#with placeInfoCount}}
-            <span class='badge on-right' title={{_ "Number of places provided by this data source"}}>{{this}}</span>
-          {{/with}}
+          <span class='badge on-right' title={{_ "Number of places provided by this data source"}}>{{this.placeInfoCount}}</span>
         </span>
 
         <div class='details'>

--- a/client/components/source/source.js
+++ b/client/components/source/source.js
@@ -1,11 +1,8 @@
 import { Template } from 'meteor/templating';
 import { SubsManager } from 'meteor/meteorhacks:subs-manager';
 
-const subsManager = new SubsManager();
-
 Template.component_source.onRendered(function rendered() {
   if (this.data.source) {
-    this.subscribe('sourcesPlaceInfoCounts', this.data.source._id);
     this.subscribe('sourceImports.public');
   }
 });


### PR DESCRIPTION
- Instead of having a function that counts place infos dynamically, cache the number of PoIs for a source after each import
- Cache new place info count in SourceImport document too after each import for statistics
- Refactor `numberOfPlaces` -> `placeInfoCount`
- Add a meteor function `cachePlaceCountForSource` to be called manually on production for each source after this is merged (so we don't have to reimport everything)
- Small improvements to .gitignore