### PR TITLE
Bugfix/improve zero places behavior

### DIFF
--- a/both/api/sources/server/methods.js
+++ b/both/api/sources/server/methods.js
@@ -53,5 +53,6 @@ Meteor.methods({
     checkExistenceAndFullAccessToSourceId(this.userId, sourceId);
 
     PlaceInfos.remove({ 'properties.sourceId': sourceId });
+    Sources.update({ _id: sourceId }, { $set: { placeInfoCount: 0 } });
   },
 });

--- a/client/pages/sources/show/sidebar/attributes.html
+++ b/client/pages/sources/show/sidebar/attributes.html
@@ -1,18 +1,20 @@
 <template name='sources_show_page_attributes'>
-  {{#with getLastSuccessfulImport}}
-    <dl class="source-attributes">
-      <dt>Structure</dt>
-      <dd>
-        <dl>
-          {{#if ../placeInfoCount}}
-            {{> sources_show_page_recursive_attributes
-              attributeName='properties'
-              placeInfoCount=../placeInfoCount
-              attributeDistribution=getCachedAttributeDistribution.properties
-              properties=getCachedAttributeDistribution.properties.properties}}
-          {{/if}}
-        </dl>
-      </dd>
-    </dl>
-  {{/with}}
+  {{#if placeInfoCount}}
+    {{#with getLastSuccessfulImport}}
+      <dl class="source-attributes">
+        <dt>Structure</dt>
+        <dd>
+          <dl>
+            {{#if ../placeInfoCount}}
+              {{> sources_show_page_recursive_attributes
+                attributeName='properties'
+                placeInfoCount=../placeInfoCount
+                attributeDistribution=getCachedAttributeDistribution.properties
+                properties=getCachedAttributeDistribution.properties.properties}}
+            {{/if}}
+          </dl>
+        </dd>
+      </dl>
+    {{/with}}
+  {{/if}}
 </template>

--- a/client/pages/sources/show/sidebar/top-stats.html
+++ b/client/pages/sources/show/sidebar/top-stats.html
@@ -19,29 +19,31 @@
     {{/if}}
   </dd>
 
-  {{#with getLastSuccessfulImport}}
-    <dt class='stats'>Accessible with…</dt>
-    <dd>
-      <ul class='stats-by-accessibility-type'>
-        {{#each placeCountsByAccessibilityType}}
-          <li>
-            <header class='type'>{{humanize name}}</header>
-            <div class='number middle'>{{formatNumber this.true}}</div>
-          </li>
-        {{/each}}
-      </ul>
-    </dd>
+  {{#if placeInfoCount}}
+    {{#with getLastSuccessfulImport}}
+      <dt class='stats'>Accessible with…</dt>
+      <dd>
+        <ul class='stats-by-accessibility-type'>
+          {{#each placeCountsByAccessibilityType}}
+            <li>
+              <header class='type'>{{humanize name}}</header>
+              <div class='number middle'>{{formatNumber this.true}}</div>
+            </li>
+          {{/each}}
+        </ul>
+      </dd>
 
-    <dt class='stats'>Top categories</dt>
-    <dd>
-      <ul class='categories'>
-        {{#each (mostFrequentCategoryNamesToPlaceCounts 12)}}
-          <li title='{{name}}'>
-            <span class='number'>{{formatNumber count}}</span>
-            <img class='icon' src='/icons/categories/{{name}}@2x.png' alt='{{name}}'>
-          </li>
-        {{/each}}
-      </ul>
-    </dd>
-  {{/with}}
+      <dt class='stats'>Top categories</dt>
+      <dd>
+        <ul class='categories'>
+          {{#each (mostFrequentCategoryNamesToPlaceCounts 12)}}
+            <li title='{{name}}'>
+              <span class='number'>{{formatNumber count}}</span>
+              <img class='icon' src='/icons/categories/{{name}}@2x.png' alt='{{name}}'>
+            </li>
+          {{/each}}
+        </ul>
+      </dd>
+    {{/with}}
+  {{/if}}
 </template>


### PR DESCRIPTION
This is a small fix for the changes in PR #9:
- Of course, when deleting all PoIs of a source, we need to reset the cached `placeInfoCount` to `0`.
- When a source has no places, we can't show sensible stats for it, so hide them.