### PR TITLE
Don't show lock icon if user can access source

### DIFF
--- a/both/api/sources/sources.js
+++ b/both/api/sources/sources.js
@@ -147,7 +147,9 @@ Sources.relationships = {
 
 Sources.helpers({
   isFullyVisibleForUserId(userId) {
-    return isAdmin(userId) || isUserMemberOfOrganizationWithId(userId, this.organizationId);
+    return isAdmin(userId)
+            || isUserMemberOfOrganizationWithId(userId, this.organizationId)
+            || this.isFreelyAccessible;
   },
   hasRestrictedAccessForUserId(userId) {
     const allowedOrganizationIDs = this.accessRestrictedTo || [];

--- a/both/api/sources/sources.js
+++ b/both/api/sources/sources.js
@@ -159,6 +159,9 @@ Sources.helpers({
 
     return !this.isFreelyAccessible && userBelongsToAnAllowedOrganization;
   },
+  isVisibleForUserId(userId) {
+    return this.isFullyVisibleForUserId(userId) || this.hasRestrictedAccessForUserId(userId);
+  },
   getOrganization() {
     return Organizations.findOne(this.organizationId);
   },

--- a/client/components/source/source.html
+++ b/client/components/source/source.html
@@ -14,7 +14,7 @@
           {{#if shouldShowOrganizationName}}
             <span class='subtle'>by {{getOrganization.name}}</span>
           {{/if}}
-          {{#unless isFreelyAccessible}}
+          {{#unless isVisible}}
             <span class="private-source-icon"></span>
           {{/unless}}
 

--- a/client/components/source/source.js
+++ b/client/components/source/source.js
@@ -1,8 +1,17 @@
+import { Meteor } from 'meteor/meteor';
 import { Template } from 'meteor/templating';
-import { SubsManager } from 'meteor/meteorhacks:subs-manager';
+import { Sources } from '/both/api/sources/sources';
 
 Template.component_source.onRendered(function rendered() {
   if (this.data.source) {
     this.subscribe('sourceImports.public');
   }
+});
+
+Template.component_source.helpers({
+  isVisible() {
+    const source = Sources.findOne(this._id);
+
+    return source && source.isVisibleForUserId(Meteor.userId());
+  },
 });


### PR DESCRIPTION
This PR fixes a regression introduced in #15 whereby the "lock" icon would be shown in more cases than necessary.

**Before**
![image](https://cloud.githubusercontent.com/assets/167537/22828464/c0eaf07a-ef9d-11e6-8731-3886825e1f0c.png)

**After**
![image](https://cloud.githubusercontent.com/assets/167537/22828499/e821da32-ef9d-11e6-87a0-61cc37293eb9.png)
