### PR TITLE
Fix exception when opening source as logged-out user

### DIFF
--- a/client/pages/sources/show/overview/map.js
+++ b/client/pages/sources/show/overview/map.js
@@ -30,7 +30,11 @@ Template.sources_show_page_map.onCreated(function created() {
   this.isShowingRequestForm = new ReactiveVar(false);
 
   subsManager.subscribe('sources.requestable.public');
-  subsManager.subscribe('sourceAccessRequests.single', Meteor.userId());
+  this.autorun(() => {
+    if (Meteor.userId()) {
+      subsManager.subscribe('sourceAccessRequests.single', Meteor.userId());
+    }
+  });
 });
 
 const reactiveVariables = [


### PR DESCRIPTION
This fixes the following exception:

```
I20170213-14:31:04.301(1)? Exception from sub sourceAccessRequests.single id 7mYXCAaoEmQuqujWd { stack: 'Error: Match error: Expected string, got null\n    at exports.check (packages/check/match.js:34:1)\n    at Subscription.<anonymous> (both/api/source-access-requests/server/publications.js:8:3)\n    at Subscription._handler (packages/peerlibrary_reactive-publish/packages/peerlibrary_reactive-publish.js:342:1)\n    at packages/check/match.js:107:1\n    at [object Object]._.extend.withValue (packages/meteor/dynamics_nodejs.js:56:1)\n    at Object.exports.Match._failIfArgumentsAreNotAllChecked (packages/check/match.js:106:1)\n    at maybeAuditArgumentChecks (packages/ddp-server/livedata_server.js:1708:18)\n    at Subscription._runHandler (packages/ddp-server/livedata_server.js:1026:17)\n    at Subscription.subscriptionProto._runHandler (packages/meteorhacks_kadira/lib/hijack/wrap_subscription.js:12:1)\n    at Session._startSubscription (packages/ddp-server/livedata_server.js:845:9)\n    at Session.sub (packages/ddp-server/livedata_server.js:617:12)\n    at packages/meteorhacks_kadira/lib/hijack/wrap_session.js:77:1\n    at [object Object]._.extend.withValue (packages/meteor/dynamics_nodejs.js:56:1)\n    at Session.sessionProto.protocol_handlers.sub (packages/meteorhacks_kadira/lib/hijack/wrap_session.js:76:1)\n    at packages/ddp-server/livedata_server.js:551:43',
I20170213-14:31:04.304(1)?   source: 'subscription' }
I20170213-14:31:04.305(1)? Sanitized and reported to the client as: Match failed [400]
```