### PR TITLE
Add Radar/Eurokey information to data format

### DIFF
--- a/both/lib/ac-format.js
+++ b/both/lib/ac-format.js
@@ -98,6 +98,8 @@ export const acFormat = {
               slopeAngle: '6%',                       //
               hasVisualSign: true,                    // needs review
               hasBrailleSign: true,
+              needsRadarKey: true,
+              needsEuroKey: true,
 
               intercom: {
                 isAvailable: true,
@@ -129,6 +131,11 @@ export const acFormat = {
           ],
           restrooms: [
             {
+              signage: {
+                unisex: true,
+                male: true,
+                female: true,
+              },
               ratingForWheelchair: 0.3,
               turningSpaceInside: '>150cm',
               hasBathTub: true,
@@ -139,7 +146,6 @@ export const acFormat = {
               hasSpaceAlongsideToilet: true,
               washBasinAccessibleWithWheelchair: true,
               shampooAccessibleWithWheelchair: true,
-
               entrance: {
                 isAutomatic: false,
                 doorWidth: '85cm',
@@ -149,6 +155,8 @@ export const acFormat = {
                 isStepFree: true,
                 turningSpaceInFront: '>150cm',
                 doorOpensToOutside: true,
+                needsRadarKey: true,
+                needsEuroKey: true,
               },
               toilet: {
                 heightOfBase: '40 .. 45cm',


### PR DESCRIPTION
Radar key and Euro key are two international standards to make restrooms accessible for people with disabilities. This format change allows to mark for which restroom you need a radar key, and which signs you need to look for to find it.

The attribute is supported by various data sources, for example https://www.accessibility.cloud/sources/wKtRH79AXcAjhA4FM.