### PR TITLE
Fix crash when aborting import w/o valid stream chain

### DIFF
--- a/both/api/sources/server/stream-chain/control-import.js
+++ b/both/api/sources/server/stream-chain/control-import.js
@@ -14,17 +14,24 @@ const sourceIdsToStreamChains = {};
 
 export function abortImport(sourceId) {
   if (sourceIdsToStreamChains[sourceId]) {
-    sourceIdsToStreamChains[sourceId][0].stream.abortChain();
+    const firstStreamObserver = sourceIdsToStreamChains[sourceId][0];
+    if (firstStreamObserver && firstStreamObserver.stream) {
+      if (typeof firstStreamObserver.stream === 'function') {
+        firstStreamObserver.stream.abortChain();
+      }
+    }
     sourceIdsToStreamChains[sourceId].forEach(streamObserver => {
-      const stream = streamObserver.stream;
       if (typeof streamObserver.abort === 'function') {
         streamObserver.abort();
       }
-      if (typeof stream.abort === 'function') {
-        stream.abort();
+      const stream = streamObserver.stream;
+      if (!stream) {
+        if (typeof stream.abort === 'function') {
+          stream.abort();
+        }
+        stream.abortStream();
+        stream.emit('abort');
       }
-      stream.abortStream();
-      stream.emit('abort');
     });
     delete sourceIdsToStreamChains[sourceId];
   }

--- a/both/api/sources/server/stream-chain/control-import.js
+++ b/both/api/sources/server/stream-chain/control-import.js
@@ -15,10 +15,9 @@ const sourceIdsToStreamChains = {};
 export function abortImport(sourceId) {
   if (sourceIdsToStreamChains[sourceId]) {
     const firstStreamObserver = sourceIdsToStreamChains[sourceId][0];
-    if (firstStreamObserver && firstStreamObserver.stream) {
-      if (typeof firstStreamObserver.stream === 'function') {
-        firstStreamObserver.stream.abortChain();
-      }
+    const firstStream = firstStreamObserver && firstStreamObserver.stream;
+    if (firstStream && typeof firstStream.abortChain === 'function') {
+      firstStream.abortChain();
     }
     sourceIdsToStreamChains[sourceId].forEach(streamObserver => {
       if (typeof streamObserver.abort === 'function') {
@@ -26,10 +25,15 @@ export function abortImport(sourceId) {
       }
       const stream = streamObserver.stream;
       if (!stream) {
-        if (typeof stream.abort === 'function') {
-          stream.abort();
-        }
+        return;
+      }
+      if (typeof stream.abort === 'function') {
+        stream.abort();
+      }
+      if (typeof stream.abortStream === 'function') {
         stream.abortStream();
+      }
+      if (typeof stream.emit === 'function') {
         stream.emit('abort');
       }
     });


### PR DESCRIPTION
This happened when the stream chain could not be correctly built in some edge cases. The code just does some more type checking before actually aborting.