### PR TITLE
Wrap DB indexing into Meteor.startup() calls

### DIFF
--- a/both/api/apps/apps.js
+++ b/both/api/apps/apps.js
@@ -68,9 +68,3 @@ Apps.helpers({
     return Organizations.findOne(this.organizationId);
   },
 });
-
-if (Meteor.isServer) {
-  Apps._ensureIndex({ organizationId: 1 });
-  Apps._ensureIndex({ tokenString: 1 });
-  Apps._ensureIndex({ tocForAppsAccepted: 1 });
-}

--- a/both/api/apps/server/indexing.js
+++ b/both/api/apps/server/indexing.js
@@ -1,0 +1,8 @@
+import { Meteor } from 'meteor/meteor';
+import { Apps } from '../apps';
+
+Meteor.startup(() => {
+  Apps._ensureIndex({ organizationId: 1 });
+  Apps._ensureIndex({ tokenString: 1 });
+  Apps._ensureIndex({ tocForAppsAccepted: 1 });
+});

--- a/both/api/licenses/licenses.js
+++ b/both/api/licenses/licenses.js
@@ -103,8 +103,3 @@ Licenses.helpers({
     return Organizations.findOne(this.organizationId);
   },
 });
-
-if (Meteor.isServer) {
-  Licenses._ensureIndex({ organizationId: 1 });
-  Licenses._ensureIndex({ consideredAs: 1 });
-}

--- a/both/api/licenses/server/indexing.js
+++ b/both/api/licenses/server/indexing.js
@@ -1,0 +1,8 @@
+import { Meteor } from 'meteor/meteor';
+import { Licenses } from '../licenses';
+
+Meteor.startup(() => {
+  Licenses._ensureIndex({ name: 1 });
+  Licenses._ensureIndex({ organizationId: 1 });
+  Licenses._ensureIndex({ consideredAs: 1 });
+});

--- a/both/api/organization-members/organization-members.js
+++ b/both/api/organization-members/organization-members.js
@@ -110,9 +110,3 @@ OrganizationMembers.helpers({
     return `<img src="${getGravatarImageUrl(this.gravatarHash)}" class='user-icon'>`;
   },
 });
-
-if (Meteor.isServer) {
-  OrganizationMembers._ensureIndex({ organizationId: 1 });
-  OrganizationMembers._ensureIndex({ userId: 1 });
-  OrganizationMembers._ensureIndex({ role: 1 });
-}

--- a/both/api/organization-members/server/indexing.js
+++ b/both/api/organization-members/server/indexing.js
@@ -1,0 +1,10 @@
+import { Meteor } from 'meteor/meteor';
+import { OrganizationMembers } from '../organization-members';
+
+Meteor.startup(() => {
+  OrganizationMembers._ensureIndex({ organizationId: 1 });
+  OrganizationMembers._ensureIndex({ invitationToken: 1 });
+  OrganizationMembers._ensureIndex({ invitationEmailAddress: 1 });
+  OrganizationMembers._ensureIndex({ userId: 1 });
+  OrganizationMembers._ensureIndex({ role: 1 });
+});

--- a/both/api/organizations/organizations.js
+++ b/both/api/organizations/organizations.js
@@ -178,7 +178,3 @@ Organizations.whereCurrentUserIsMember = () => {
 };
 
 Organizations.attachSchema(Organizations.schema);
-
-if (Meteor.isServer) {
-  Organizations._ensureIndex({ tocForOrganizationsAccepted: 1 });
-}

--- a/both/api/organizations/server/indexing.js
+++ b/both/api/organizations/server/indexing.js
@@ -1,0 +1,7 @@
+import { Meteor } from 'meteor/meteor';
+import { Organizations } from '../organizations';
+
+Meteor.startup(() => {
+  Organizations._ensureIndex({ name: 1 });
+  Organizations._ensureIndex({ tocForOrganizationsAccepted: 1 });
+});

--- a/both/api/place-infos/place-infos.js
+++ b/both/api/place-infos/place-infos.js
@@ -60,13 +60,3 @@ PlaceInfos.relationships = {
 PlaceInfos.helpers(helpers);
 
 PlaceInfos.includePathsByDefault = ['source.license'];
-
-if (Meteor.isServer) {
-  PlaceInfos._ensureIndex({ 'properties.sourceId': 1 });
-  PlaceInfos._ensureIndex({ 'properties.sourceImportId': 1 });
-  PlaceInfos._ensureIndex({ 'properties.category': 1 });
-  PlaceInfos._ensureIndex({ 'properties.name': 1 });
-  PlaceInfos._ensureIndex({ 'properties.accessibility.accessibleWith.wheelchair': 1 });
-  PlaceInfos._ensureIndex({ 'properties.originalId': 1 });
-  PlaceInfos._ensureIndex({ 'properties.sourceId': 1, 'properties.originalId': 1 });
-}

--- a/both/api/place-infos/server/indexing.js
+++ b/both/api/place-infos/server/indexing.js
@@ -1,0 +1,15 @@
+import { Meteor } from 'meteor/meteor';
+import { PlaceInfos } from '../place-infos';
+
+Meteor.startup(() => {
+  PlaceInfos._ensureIndex({ 'properties.sourceId': 1 });
+  PlaceInfos._ensureIndex({ 'properties.sourceImportId': 1 });
+  PlaceInfos._ensureIndex({ 'properties.category': 1 });
+  PlaceInfos._ensureIndex({ 'properties.name': 1 });
+  PlaceInfos._ensureIndex({ 'properties.accessibility.accessibleWith.wheelchair': 1 });
+  PlaceInfos._ensureIndex({ 'properties.originalId': 1 });
+  PlaceInfos._ensureIndex({ 'properties.sourceId': 1, 'properties.originalId': 1 });
+
+  console.log('Ensuring geospatial index for PlaceInfos...');
+  PlaceInfos._ensureIndex({ geometry: '2dsphere' });
+});

--- a/both/api/place-infos/server/publications.js
+++ b/both/api/place-infos/server/publications.js
@@ -23,6 +23,3 @@ Meteor.publish('placeInfos.single', function publish(placeInfoId) {
   };
   return PlaceInfos.find(selector, options);
 });
-
-console.log('Ensuring geospatial index for PlaceInfos...');
-PlaceInfos._ensureIndex({ geometry: '2dsphere' });

--- a/both/api/source-imports/server/indexing.js
+++ b/both/api/source-imports/server/indexing.js
@@ -1,0 +1,7 @@
+import { Meteor } from 'meteor/meteor';
+import { SourceImports } from '../source-imports';
+
+Meteor.startup(() => {
+  SourceImports._ensureIndex({ sourceId: 1 });
+  SourceImports._ensureIndex({ organizationId: 1 });
+});

--- a/both/api/source-imports/source-imports.js
+++ b/both/api/source-imports/source-imports.js
@@ -50,13 +50,8 @@ SourceImports.helpers({
   },
   upsertStream() {
     if (!this.streamChain) {
-      return;
+      return null;
     }
     return this.streamChain.find(stream => stream && stream.type === 'UpsertPlace');
   },
 });
-
-if (Meteor.isServer) {
-  SourceImports._ensureIndex({ sourceId: 1 });
-  SourceImports._ensureIndex({ organizationId: 1 });
-}

--- a/both/api/sources/server/indexing.js
+++ b/both/api/sources/server/indexing.js
@@ -1,0 +1,12 @@
+import { Meteor } from 'meteor/meteor';
+import { Sources } from '../sources';
+
+Meteor.startup(() => {
+  Sources._ensureIndex({ licenseId: 1 });
+  Sources._ensureIndex({ languageId: 1 });
+  Sources._ensureIndex({ name: 1 });
+  Sources._ensureIndex({ isFreelyAccessible: 1 });
+  Sources._ensureIndex({ isDraft: 1 });
+  Sources._ensureIndex({ accessRestrictedTo: 1 });
+  Sources._ensureIndex({ organizationId: 1 });
+});

--- a/both/api/sources/sources.js
+++ b/both/api/sources/sources.js
@@ -202,13 +202,3 @@ Sources.helpers({
       .find(i => (!i.hasError() && !i.isAborted()));
   },
 });
-
-if (Meteor.isServer) {
-  SourceImports._ensureIndex({ licenseId: 1 });
-  SourceImports._ensureIndex({ languageId: 1 });
-  SourceImports._ensureIndex({ name: 1 });
-  SourceImports._ensureIndex({ isFreelyAccessible: 1 });
-  SourceImports._ensureIndex({ isDraft: 1 });
-  SourceImports._ensureIndex({ accessRestrictedTo: 1 });
-  SourceImports._ensureIndex({ organizationId: 1 });
-}


### PR DESCRIPTION
This hopefully speeds up restarts. It also adds some more indexes and fixes a big bug: `Sources` was not indexed at all. Indexing this one should lead to visible performance improvements as almost every RPC method, JSON API call and publication relies on `Sources` attributes for authorization.