### PR TITLE
Improve license types

### DIFF
--- a/both/api/licenses/licenses.js
+++ b/both/api/licenses/licenses.js
@@ -77,11 +77,10 @@ Licenses.schema = new SimpleSchema({
     autoform: {
       afFieldInput: {
         options: [
-          { label: 'undefined', value: '' },
           { label: 'Public Domain (CC0)', value: 'CC0' },
           { label: 'Free, with Attribution required (CCBY)', value: 'CCBY' },
           { label: 'Share Alike (CCSA)', value: 'CCSA' },
-          { label: 'Restricted ($)', value: 'restricted' },
+          { label: 'Restricted / Proprietary (©)', value: 'restricted' },
         ],
       },
     },


### PR DESCRIPTION
The 'undefined' license type does not make much sense. If a use does not know about what kind of license they add, they better use 'restricted'.