### PR TITLE
Prevent last member removal

### DIFF
--- a/both/api/organizations/server/methods.js
+++ b/both/api/organizations/server/methods.js
@@ -37,6 +37,7 @@ export const remove = new ValidatedMethod({
         'You don\'t have permission to remove this organization.');
     }
 
+    OrganizationMembers.remove({ organizationId });
     Organizations.remove(organizationId);
   },
 });

--- a/client/pages/members/list.html
+++ b/client/pages/members/list.html
@@ -17,7 +17,9 @@
             <span class='input'>
               {{> afFieldInput name='role' type='select' label=false}}
             </span>
-            <button class='btn btn-danger btn-inline js-remove-member'>Revoke membership</button>
+            {{#if organizationHasMoreThanOneMember}}
+              <button class='btn btn-danger btn-inline js-remove-member'>Revoke membership</button>
+            {{/if}}
           {{/autoForm}}
         </li>
       {{/each}}

--- a/client/pages/members/list.js
+++ b/client/pages/members/list.js
@@ -45,6 +45,10 @@ Template.members_list_page.helpers({
   memberRoleSchema() {
     return OrganizationMembers.schema.pick(['role']);
   },
+  organizationHasMoreThanOneMember() {
+    const organizationId = FlowRouter.getParam('_id');
+    return OrganizationMembers.find({ organizationId }).count() > 1;
+  },
   members() {
     const orga = getOrganizationForView();
     if (orga) {

--- a/client/pages/members/list.js
+++ b/client/pages/members/list.js
@@ -67,7 +67,7 @@ Template.members_list_page.helpers({
 Template.members_list_page.events({
   'click .js-remove-member'(event) {
     if (confirm('Do you really want to remove this member?')) {
-      OrganizationMembers.remove(this._id, error => {
+      Meteor.call('organizationMembers.remove', this._id, error => {
         if (error) {
           alert(`Could not remove member: ${error}`);
         }


### PR DESCRIPTION
Before this you could delete the last membership of an organization which leads to other bugs.

The new code
- …checks on UI and server side that you can't do this anymore (the last member's 'revoke membership' button is now hidden, too)
- …deletes the memberships of an organization when deleting the organization itself. This prevents bugs where the code searches for organizations by looking at your memberships.