### PR TITLE
Bugfix/source import privileges

### DIFF
--- a/both/api/source-imports/server/privileges.js
+++ b/both/api/source-imports/server/privileges.js
@@ -19,6 +19,7 @@ SourceImports.publicFields = {
 
 SourceImports.statsFields = {
   startTimestamp: 1,
+  isFinished: 1,
   insertedPlaceInfoCount: 1,
   updatedPlaceInfoCount: 1,
   placeInfoCountAfterImport: 1,
@@ -45,21 +46,23 @@ SourceImports.helpers({
   },
 });
 
+// An import is visible if the user has access to its source.
 SourceImports.visibleSelectorForUserId = (userId) => {
-  if (!userId) {
-    return null;
-  }
-
+  if (!userId) { return null; }
   check(userId, String);
+  const selector = Sources.visibleSelectorForUserId(userId);
+  const sourceIds = Sources.find(selector, { fields: { _id: 1 } }).fetch().map(s => s._id);
   return {
-    organizationId: { $in: getAccessibleOrganizationIdsForUserId(userId) },
+    sourceId: { $in: sourceIds },
   };
 };
 
 SourceImports.visibleSelectorForAppId = (appId) => {
   check(appId, String);
+  const selector = Sources.visibleSelectorForAppId(appId);
+  const sourceIds = Sources.find(selector, { fields: { _id: 1 } }).fetch().map(s => s._id);
   return {
-    sourceId: { $in: Sources.visibleSelectorForAppId(appId) },
+    sourceId: { $in: sourceIds },
   };
 };
 

--- a/client/_layouts/app-layout-full-size.less
+++ b/client/_layouts/app-layout-full-size.less
@@ -2,7 +2,7 @@
 @import "/client/stylesheets/map.import.less";
 
 .full-height {
-  min-height: 100vh;
+  height: 100vh;
   display: flex;
   flex-direction: column;
 


### PR DESCRIPTION
- Because `isFinished` was not in the stats fields, people who could see stats could not see the last successful import. This is fixed.
- `SourceImports.visibleSelectorForUserId` now returns imports for all sources that you’re allowed to see.
- `SourceImports.visibleSelectorForAppId` now returns imports for all sources that the given app can see.
