### PR TITLE
Add support for multiple import flows per source

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -95,3 +95,4 @@ themeteorchef:bert
 practicalmeteor:mocha
 practicalmeteor:chai
 dispatch:mocha-phantomjs
+percolate:migrations

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -100,6 +100,7 @@ peerlibrary:fiber-utils@0.6.0
 peerlibrary:reactive-mongo@0.1.1
 peerlibrary:reactive-publish@0.3.0
 peerlibrary:server-autorun@0.5.2
+percolate:migrations@0.9.8
 percolate:momentum@0.7.2
 percolate:velocityjs@1.2.1_1
 practicalmeteor:chai@2.1.0_1

--- a/both/api/import-flows/import-flows.js
+++ b/both/api/import-flows/import-flows.js
@@ -42,6 +42,9 @@ ImportFlows.helpers({
             && downloadItem.parameters
             && downloadItem.parameters.inputMimeType;
   },
+  hasStreams() {
+    return this.streams && this.streams.length > 0;
+  },
   getStreams() {
     return this.streams;
   },

--- a/both/api/import-flows/import-flows.js
+++ b/both/api/import-flows/import-flows.js
@@ -1,0 +1,46 @@
+import { Meteor } from 'meteor/meteor';
+import { Mongo } from 'meteor/mongo';
+import { SimpleSchema } from 'meteor/aldeed:simple-schema';
+
+export const ImportFlows = new Mongo.Collection('ImportFlows');
+
+ImportFlows.schema = new SimpleSchema({
+  sourceId: {
+    type: String,
+    regEx: SimpleSchema.RegEx.Id,
+  },
+  name: {
+    label: 'Name',
+    type: String,
+  },
+  createdAt: {
+    type: Number,
+  },
+  streams: {
+    type: Array,
+    label: 'Stream chain setup',
+    optional: true,
+  },
+  'streams.$': {
+    type: Object,
+    blackbox: true,
+  },
+  'streams.$.type': {
+    type: String,
+  },
+});
+
+ImportFlows.attachSchema(ImportFlows.schema);
+
+ImportFlows.helpers({
+  getStreams() {
+    return this.streams;
+  },
+  getFirstStream() {
+    return this.streams[0];
+  },
+});
+
+if (Meteor.isServer) {
+  ImportFlows._ensureIndex({ sourceId: 1 });
+}

--- a/both/api/import-flows/import-flows.js
+++ b/both/api/import-flows/import-flows.js
@@ -33,11 +33,29 @@ ImportFlows.schema = new SimpleSchema({
 ImportFlows.attachSchema(ImportFlows.schema);
 
 ImportFlows.helpers({
+  inputMimeType() {
+    const downloadItem = this.streams.find(
+      ({ type }) => type === 'HTTPDownload'
+    );
+
+    return downloadItem
+            && downloadItem.parameters
+            && downloadItem.parameters.inputMimeType;
+  },
   getStreams() {
     return this.streams;
   },
   getFirstStream() {
     return this.streams[0];
+  },
+  hasDownloadStep() {
+    if (!this.streams) {
+      return false;
+    }
+
+    return this.streams.some(
+      step => step.type === 'HTTPDownload' && !!step.parameters.sourceUrl
+    );
   },
 });
 

--- a/both/api/import-flows/server/privileges.js
+++ b/both/api/import-flows/server/privileges.js
@@ -1,0 +1,16 @@
+import { isAdmin } from '/both/lib/is-admin';
+import { ImportFlows } from '../import-flows.js';
+import { Sources } from '../../sources/sources';
+
+const canEditSource = (userId, doc) => {
+  const { sourceId } = doc;
+  const source = Sources.findOne(sourceId);
+
+  return source.isEditableBy(userId);
+};
+
+ImportFlows.allow({
+  insert: canEditSource,
+  update: canEditSource,
+  remove: canEditSource,
+});

--- a/both/api/import-flows/server/publications.js
+++ b/both/api/import-flows/server/publications.js
@@ -1,0 +1,13 @@
+import { Meteor } from 'meteor/meteor';
+import { check } from 'meteor/check';
+import { ImportFlows } from '../import-flows.js';
+
+const options = { fields: ImportFlows.publicFields };
+
+Meteor.publish('importFlows.forSource', sourceId => {
+  check(sourceId, String);
+
+  const selector = { sourceId };
+
+  return ImportFlows.find(selector, options);
+});

--- a/both/api/sources/server/methods.js
+++ b/both/api/sources/server/methods.js
@@ -4,6 +4,7 @@ import { check } from 'meteor/check';
 import { PlaceInfos } from '/both/api/place-infos/place-infos.js';
 import { SourceImports } from '/both/api/source-imports/source-imports.js';
 import { Sources } from '/both/api/sources/sources.js';
+import { ImportFlows } from '/both/api/import-flows/import-flows.js';
 import {
   checkExistenceAndFullAccessToSourceId,
   checkExistenceAndVisibilityForSourceId,
@@ -25,16 +26,16 @@ Meteor.methods({
     Sources.update(sourceId, { $set: { placeInfoCount } });
   },
 
-  updateDataURLForSource(sourceId, url) {
-    check(sourceId, String);
+  updateDataURLForImportFlow(importFlowId, url) {
+    const importFlow = ImportFlows.findOne(importFlowId);
+
+    check(importFlowId, String);
     check(url, String);
-    // check(url, SimpleSchema.RegEx.Url);
-    checkExistenceAndFullAccessToSourceId(this.userId, sourceId);
+    checkExistenceAndFullAccessToSourceId(this.userId, importFlow.sourceId);
 
-    Sources.update(sourceId, { $set: {
-      'streamChain.0.parameters.sourceUrl': url,
-    } });// , { bypassCollection2: true });
-
+    ImportFlows.update(importFlowId, { $set: {
+      'streams.0.parameters.sourceUrl': url,
+    } });
 
     return true;
   },

--- a/both/api/sources/server/privileges.js
+++ b/both/api/sources/server/privileges.js
@@ -32,10 +32,6 @@ Sources.publicFields = {
   placeInfoCount: 1,
 };
 
-Sources.privateFields = {
-  streamChain: 1,
-};
-
 Sources.helpers({
   editableBy(userId) {
     check(userId, String);

--- a/both/api/sources/sources.js
+++ b/both/api/sources/sources.js
@@ -167,6 +167,14 @@ Sources.helpers({
       .fetch()
       .find(i => (!i.hasError() && !i.isAborted()));
   },
+  getLastSourceImport() {
+    const sourceId = this._id;
+    const latestImport = SourceImports.findOne({ sourceId }, { sort: { startTimestamp: -1 } });
+    if (latestImport) {
+      return latestImport;
+    }
+    return null;
+  },
   getImportFlows() {
     return ImportFlows.find(
       { sourceId: this._id },

--- a/both/api/sources/sources.js
+++ b/both/api/sources/sources.js
@@ -1,9 +1,7 @@
-import { _ } from 'meteor/underscore';
-import { Meteor } from 'meteor/meteor';
 import { Mongo } from 'meteor/mongo';
 import { SimpleSchema } from 'meteor/aldeed:simple-schema';
 import { isAdmin } from '/both/lib/is-admin';
-
+import { ImportFlows } from '/both/api/import-flows/import-flows';
 import { Licenses } from '/both/api/licenses/licenses';
 import { Organizations } from '/both/api/organizations/organizations';
 import { SourceImports } from '/both/api/source-imports/source-imports';
@@ -76,18 +74,6 @@ Sources.schema = new SimpleSchema({
     label: 'Only a draft (content not available to people outside your organization)',
     defaultValue: true,
     optional: true,
-  },
-  streamChain: {
-    type: Array,
-    label: 'Stream chain setup',
-    optional: true,
-  },
-  'streamChain.$': {
-    type: Object,
-    blackbox: true,
-  },
-  'streamChain.$.type': {
-    type: String,
   },
   isFreelyAccessible: {
     type: Boolean,
@@ -180,5 +166,22 @@ Sources.helpers({
       .find({ sourceId: this._id, isFinished: true }, { sort: { startTimestamp: -1 } })
       .fetch()
       .find(i => (!i.hasError() && !i.isAborted()));
+  },
+  getImportFlows() {
+    return ImportFlows.find(
+      { sourceId: this._id },
+      { sort: { createdAt: 1 } }
+    );
+  },
+  addImportFlow({
+    name = 'Default',
+    streams,
+  }) {
+    ImportFlows.insert({
+      sourceId: this._id,
+      name,
+      streams,
+      createdAt: Date.now(),
+    });
   },
 });

--- a/both/api/sources/sources.js
+++ b/both/api/sources/sources.js
@@ -179,13 +179,6 @@ Sources.helpers({
     const downloadItem = _.find(this.streamChain, chainItem => chainItem.type === 'HTTPDownload');
     return (downloadItem && downloadItem.parameters && downloadItem.parameters.inputMimeType);
   },
-  inputMimeTypeName() {
-    switch (this.inputMimeType()) {
-      case 'application/json': return 'JSON';
-      case 'text/csv': return 'CSV';
-      default: return '(Unknown format)';
-    }
-  },
   hasDownloadStep() {
     // This should be using SimpleSchema validators on all mappings steps to validate the mappings.
     if (!this.streamChain) {

--- a/both/api/sources/sources.js
+++ b/both/api/sources/sources.js
@@ -175,19 +175,6 @@ Sources.helpers({
   getLicense() {
     return Licenses.findOne(this.licenseId);
   },
-  inputMimeType() {
-    const downloadItem = _.find(this.streamChain, chainItem => chainItem.type === 'HTTPDownload');
-    return (downloadItem && downloadItem.parameters && downloadItem.parameters.inputMimeType);
-  },
-  hasDownloadStep() {
-    // This should be using SimpleSchema validators on all mappings steps to validate the mappings.
-    if (!this.streamChain) {
-      return false;
-    }
-    const hasDownloadStep = !!this.streamChain.find((step) =>
-      step.type === 'HTTPDownload' && !!step.parameters.sourceUrl);
-    return hasDownloadStep;
-  },
   getLastSuccessfulImport() {
     return SourceImports
       .find({ sourceId: this._id, isFinished: true }, { sort: { startTimestamp: -1 } })

--- a/client/_layouts/app-layout-scrollable.less
+++ b/client/_layouts/app-layout-scrollable.less
@@ -134,6 +134,7 @@ header.main-header {
 header.main-header .sub-header {
   display: inline-block;
   margin-top: 8px;
+  width: 100%;
   padding-left: @page-horizontal-padding;
 
   .sub-pages {

--- a/client/pages/sources/show/format/format.html
+++ b/client/pages/sources/show/format/format.html
@@ -31,7 +31,12 @@
 
               <p>
                 If you don't have an API, you can also upload a JSON or CSV file:
-                {{> fileUpload additionalCSSClasses='btn btn-primary' accept=source.inputMimeType title='Upload {{source.inputMimeTypeName}}' metadata=fileMetadata callbacks=fileCallbacks}}
+                {{> fileUpload
+                      additionalCSSClasses='btn btn-primary'
+                      accept=source.inputMimeType
+                      metadata=fileMetadata
+                      callbacks=fileCallbacks
+                }}
               </p>
 
               {{#if source.isDraft}}

--- a/client/pages/sources/show/format/format.html
+++ b/client/pages/sources/show/format/format.html
@@ -63,9 +63,17 @@
             }}
           </div>
           {{#if source.hasRunningImport}}
-            <button class="js-abort-import">&#x32;</button>
+            <button
+              class="js-abort-import"
+              title="Abort import">
+              &#x32;
+            </button>
           {{else}}
-            <button class="js-start-import">&#x31;</button>
+            <button
+              class="js-start-import"
+              title="Start import">
+              &#x31;
+            </button>
           {{/if}}
         </div>
 

--- a/client/pages/sources/show/format/format.html
+++ b/client/pages/sources/show/format/format.html
@@ -16,6 +16,12 @@
               </a>
             </li>
           {{/each}}
+          <button
+            class="add-import-flow"
+            title="Add import flow"
+          >
+            &#xE80F;
+          </button>
         </ul>
 
         <textarea class='code code-block' id='importFlow'>{{stringify currentImportFlow.streams}}</textarea>

--- a/client/pages/sources/show/format/format.html
+++ b/client/pages/sources/show/format/format.html
@@ -11,33 +11,16 @@
           <ul class='errors is-empty'>
           </ul>
 
-          <p>
-            The JSON block on the left defines where your data comes from and how it is formatted:
-          </p>
-
-          <p>
-            You can find more information and examples in <a href='https://github.com/sozialhelden/accessibility-cloud/blob/master/docs/importing-data.md'>our documentation</a>.
-          </p>
-
-          <p>
-            If you feel lost, we are eager to help you! Just <a href='mailto:support@accessibility.cloud'>write us an email</a> and we will help you get started.
-          </p>
-
           {{#unless source.hasRunningImport}}
             {{#if source.hasDownloadStep}}
-              <p>
-                <button class='btn js-start-import btn btn-primary btn-inline'>Start</button> to test if your flow works and get debug information.
-              </p>
+              <button class='btn js-start-import btn btn-primary btn-inline'>Start</button>
 
-              <p>
-                If you don't have an API, you can also upload a JSON or CSV file:
-                {{> fileUpload
-                      additionalCSSClasses='btn btn-primary'
-                      accept=source.inputMimeType
-                      metadata=fileMetadata
-                      callbacks=fileCallbacks
-                }}
-              </p>
+              {{> fileUpload
+                    additionalCSSClasses='btn btn-primary'
+                    accept=source.inputMimeType
+                    metadata=fileMetadata
+                    callbacks=fileCallbacks
+              }}
 
               {{#if source.isDraft}}
                 <p>

--- a/client/pages/sources/show/format/format.html
+++ b/client/pages/sources/show/format/format.html
@@ -1,52 +1,57 @@
 <template name="sources_show_format_page">
   {{#with source}}
-    {{#if streamChain}}
+    {{#if currentImportFlow}}
     <section class='edit-stream-chain'>
       <section class='stream-chain'>
-        <textarea class='code code-block' id='streamChain'>{{stringify streamChain}}</textarea>
+        <ul class="source-import-flows-tabs">
+          {{#each source.getImportFlows}}
+            <li {{getClassNameForImportFlowListItem _id}}>
+              {{name}}
+            </li>
+          {{/each}}
+        </ul>
+
+        <textarea class='code code-block' id='importFlow'>{{stringify currentImportFlow.streams}}</textarea>
       </section>
 
       <aside>
-        <header>
-          <ul class='errors is-empty'>
-          </ul>
+        <div class="import-flow-actions">
+          <div class="import-flow-help-wrapper">
+            <button>&#xE80A;</button>
+            <div class="import-flow-help">
+              {{> import_flow_help }}
+            </div>
+          </div>
+          {{#if getNotificationsForImportFlow.length}}
+            <div class="import-flow-notifications-wrapper">
+              <button>&#xE816;</button>
+              <div class="import-flow-notifications">
+                {{#each getNotificationsForImportFlow}}
+                  <p>
+                    {{{this}}}
+                  </p>
+                {{/each}}
+              </div>
+            </div>
+          {{/if}}
+          <div class="import-flow-file-uploader-wrapper">
+            &#xE815;
+            {{> fileUpload
+                  additionalCSSClasses='import-flow-file-uploader'
+                  accept=source.currentImportFlow.inputMimeType
+                  metadata=fileMetadata
+                  callbacks=fileCallbacks
+            }}
+          </div>
+          <button class="js-start-import">&#x31;</button>
+        </div>
 
-          {{#unless source.hasRunningImport}}
-            {{#if source.hasDownloadStep}}
-              <button class='btn js-start-import btn btn-primary btn-inline'>Start</button>
-
-              {{> fileUpload
-                    additionalCSSClasses='btn btn-primary'
-                    accept=source.inputMimeType
-                    metadata=fileMetadata
-                    callbacks=fileCallbacks
-              }}
-
-              {{#if source.isDraft}}
-                <p>
-                  Your data will only be visible to members of {{source.getOrganization.name}} as your source is set to draft mode.
-                </p>
-              {{/if}}
-            {{else}}
-              <p>
-                Your source import flow is still missing a <code>HTTPDownload</code> step. Please add it to enable importing your data.
-              </p>
-            {{/if}}
-          {{/unless}}
-        </header>
-
-        {{#if lastSourceImport}}
-          {{#with lastSourceImport}}
-            {{> sources_stream_chain}}
-          {{else}}
-            <h2>{{_"Latest Import"}}</h2>
-            <p class='placeholder'>{{_"Here you will see your last imports"}}</p>
-          {{/with}}
+        {{#with lastSourceImport}}
+          {{> sources_stream_chain}}
         {{else}}
-          <p>
-            Please insert a JSON that describes the data flow from your input source into the accessibility.cloud database on the left side.
-          </p>
-        {{/if}}
+          <h2>{{_"Latest Import"}}</h2>
+          <p class='placeholder'>{{_"Here you will see your last imports"}}</p>
+        {{/with}}
       </aside>
     </section>
     {{else}}

--- a/client/pages/sources/show/format/format.html
+++ b/client/pages/sources/show/format/format.html
@@ -51,7 +51,11 @@
                   callbacks=fileCallbacks
             }}
           </div>
-          <button class="js-start-import">&#x31;</button>
+          {{#if source.hasRunningImport}}
+            <button class="js-abort-import">&#x32;</button>
+          {{else}}
+            <button class="js-start-import">&#x31;</button>
+          {{/if}}
         </div>
 
         {{#if getLastSourceImport}}

--- a/client/pages/sources/show/format/format.html
+++ b/client/pages/sources/show/format/format.html
@@ -19,6 +19,7 @@
         </ul>
 
         <textarea class='code code-block' id='importFlow'>{{stringify currentImportFlow.streams}}</textarea>
+        <ul class='import-flow-errors is-empty'></ul>
       </section>
 
       <aside>

--- a/client/pages/sources/show/format/format.html
+++ b/client/pages/sources/show/format/format.html
@@ -14,6 +14,11 @@
                       }}">
                 {{name}}
               </a>
+              <button
+                class="delete-import-flow-icon"
+                title="Delete import flow">
+                &#xE80C;
+              </button>
             </li>
           {{/each}}
           <button

--- a/client/pages/sources/show/format/format.html
+++ b/client/pages/sources/show/format/format.html
@@ -54,12 +54,15 @@
           <button class="js-start-import">&#x31;</button>
         </div>
 
-        {{#with lastSourceImport}}
-          {{> sources_stream_chain}}
+        {{#if getLastSourceImport}}
+          {{> sources_stream_chain
+                source=this
+                hideAbortButton=true
+          }}
         {{else}}
           <h2>{{_"Latest Import"}}</h2>
           <p class='placeholder'>{{_"Here you will see your last imports"}}</p>
-        {{/with}}
+        {{/if}}
       </aside>
     </section>
     {{else}}

--- a/client/pages/sources/show/format/format.html
+++ b/client/pages/sources/show/format/format.html
@@ -4,9 +4,16 @@
     <section class='edit-stream-chain'>
       <section class='stream-chain'>
         <ul class="source-import-flows-tabs">
-          {{#each source.getImportFlows}}
+          {{#each getImportFlows}}
             <li {{getClassNameForImportFlowListItem _id}}>
-              {{name}}
+              <a
+                href="{{pathFor
+                          route='sources.show.format.for_import_flow'
+                          _id=sourceId
+                          import_flow_index=urlIndex
+                      }}">
+                {{name}}
+              </a>
             </li>
           {{/each}}
         </ul>

--- a/client/pages/sources/show/format/format.html
+++ b/client/pages/sources/show/format/format.html
@@ -1,6 +1,6 @@
 <template name="sources_show_format_page">
   {{#with source}}
-    {{#if currentImportFlow}}
+    {{#if currentImportFlowHasStreams}}
     <section class='edit-stream-chain'>
       <section class='stream-chain'>
         <ul class="source-import-flows-tabs">

--- a/client/pages/sources/show/format/format.js
+++ b/client/pages/sources/show/format/format.js
@@ -35,14 +35,6 @@ const helpers = {
   sourceImports() {
     return SourceImports.find({ sourceId: FlowRouter.getParam('_id') });
   },
-  lastSourceImport() {
-    const sourceId = FlowRouter.getParam('_id');
-    const latestImport = SourceImports.findOne({ sourceId }, { sort: { startTimestamp: -1 } });
-    if (latestImport) {
-      return latestImport;
-    }
-    return null;
-  },
   fileMetadata() {
     return {
       sourceId: FlowRouter.getParam('_id'),

--- a/client/pages/sources/show/format/format.js
+++ b/client/pages/sources/show/format/format.js
@@ -220,6 +220,26 @@ Template.sources_show_format_page.events({
     });
     FlowRouter.go(newFlowPath);
   },
+  'click .delete-import-flow-icon'() {
+    const message = 'Are you sure you want to delete this import flow?';
+    const shouldBeDeleted = confirm(message);
+
+
+    if (shouldBeDeleted) {
+      const currentImportFlow = helpers.currentImportFlow();
+      ImportFlows.remove(currentImportFlow._id);
+
+      const source = getSource();
+      const importFlowsCount = source.getImportFlows().count();
+      const indexOfNewlyDisplayedImportFlow = Math.max(importFlowsCount, 1);
+
+      const newFlowPath = FlowRouter.path('sources.show.format.for_import_flow', {
+        _id: FlowRouter.getParam('_id'),
+        import_flow_index: indexOfNewlyDisplayedImportFlow,
+      });
+      FlowRouter.go(newFlowPath);
+    }
+  },
   'click .js-start-import'(event) {
     const importFlowId = helpers.currentImportFlow()._id;
     event.preventDefault();

--- a/client/pages/sources/show/format/format.js
+++ b/client/pages/sources/show/format/format.js
@@ -200,6 +200,17 @@ Template.sources_show_format_page.events({
       }
     });
   },
+  'click .js-abort-import'(event) {
+    event.preventDefault();
+    const sourceId = getSource()._id;
+
+    Meteor.call('sources.abortImport', sourceId, (err) => {
+      if (err) {
+        console.log(err);
+        alert(err);
+      }
+    });
+  },
   'blur textarea#importFlow'(event, instance) {
     const newImportFlow = parseImportFlowDefinition(instance);
     if (!newImportFlow) {

--- a/client/pages/sources/show/format/format.js
+++ b/client/pages/sources/show/format/format.js
@@ -141,6 +141,10 @@ const helpers = {
       skip: index,
     });
   },
+  currentImportFlowHasStreams() {
+    const importFlow = helpers.currentImportFlow();
+    return importFlow && importFlow.hasStreams();
+  },
   isCurrentImportFlow(id) {
     return helpers.currentImportFlow()._id === id;
   },
@@ -183,10 +187,20 @@ Template.sources_show_format_page.events({
       throw new Error(`${templateName} template has no valid stream chain`);
     }
 
-    const source = getSource();
-    source.addImportFlow({
-      streams: streamChain,
-    });
+    const currentImportFlow = helpers.currentImportFlow();
+
+    if (currentImportFlow) {
+      ImportFlows.update(currentImportFlow._id, {
+        $set: {
+          streams: streamChain,
+        },
+      });
+    } else {
+      const source = getSource();
+      source.addImportFlow({
+        streams: streamChain,
+      });
+    }
   },
   'click .add-import-flow'() {
     const source = getSource();

--- a/client/pages/sources/show/format/format.js
+++ b/client/pages/sources/show/format/format.js
@@ -157,6 +157,11 @@ const helpers = {
       'class': helpers.isCurrentImportFlow(id) ? 'current-import-flow-tab' : '',
     };
   },
+  getImportFlows() {
+    return getSource().getImportFlows().map((doc, i) => Object.assign({}, doc, {
+      urlIndex: i + 1,
+    }));
+  },
 };
 
 function parseImportFlowDefinition(instance) {

--- a/client/pages/sources/show/format/format.js
+++ b/client/pages/sources/show/format/format.js
@@ -170,15 +170,15 @@ function parseImportFlowDefinition(instance) {
   try {
     newImportFlow = JSON.parse(newImportFlowText);
   } catch (error) {
-    $('.errors').html(`<strong>Invalid JSON:</strong> ${error.message}`);
-    $('.errors').removeClass('is-empty');
+    $('.import-flow-errors').html(`<strong>Invalid JSON:</strong> ${error.message}`);
+    $('.import-flow-errors').removeClass('is-empty');
   }
   return newImportFlow;
 }
 
 function addError(errorHTML) {
-  $('.errors').append(`<li>${errorHTML}</li>`);
-  $('.errors').removeClass('is-empty');
+  $('.import-flow-errors').append(`<li>${errorHTML}</li>`);
+  $('.import-flow-errors').removeClass('is-empty');
 }
 
 Template.sources_show_format_page.helpers(helpers);
@@ -243,7 +243,7 @@ Template.sources_show_format_page.events({
     }
   },
   'input textarea#importFlow'(event, instance) {
-    $('.errors').html('').addClass('is-empty');
+    $('.import-flow-errors').html('').addClass('is-empty');
 
     const newImportFlow = parseImportFlowDefinition(instance);
     if (!newImportFlow) {

--- a/client/pages/sources/show/format/format.js
+++ b/client/pages/sources/show/format/format.js
@@ -89,7 +89,7 @@ const helpers = {
               showError(error.message || error.reason);
               return;
             }
-            Meteor.call('sources.startImport', source._id);
+            Meteor.call('sources.startImport', importFlowId);
           }
         );
 
@@ -191,12 +191,13 @@ Template.sources_show_format_page.events({
       streams: streamChain,
     });
   },
-  'click .btn.js-start-import'(event) {
+  'click .js-start-import'(event) {
+    const importFlowId = helpers.currentImportFlow()._id;
     event.preventDefault();
 
-    Meteor.call('sources.startImport', FlowRouter.getParam('_id'), error => {
+    Meteor.call('sources.startImport', importFlowId, error => {
       if (error) {
-        alert(`Could not start import: ${error.reason}`);
+        alert(`Could not start import flow: ${error.reason}`);
       } else {
         console.log('Import started');
       }

--- a/client/pages/sources/show/format/format.js
+++ b/client/pages/sources/show/format/format.js
@@ -69,16 +69,20 @@ const helpers = {
           );
         }
 
-        const firstStream = source.streamChain && source.streamChain[0];
+        const currentImportFlow = helpers.currentImportFlow();
+        const firstStream = currentImportFlow.getFirstStream();
+
         if (!firstStream || firstStream.type !== 'HTTPDownload') {
           return showError(
             'Please setup the source format first so it has a HTTP download stream.'
           );
         }
 
+        const importFlowId = currentImportFlow._id;
+
         Meteor.call(
-          'updateDataURLForSource',
-          source._id,
+          'updateDataURLForImportFlow',
+          importFlowId,
           response.uploadedFile.storageUrl,
           (error) => {
             if (error) {

--- a/client/pages/sources/show/format/format.js
+++ b/client/pages/sources/show/format/format.js
@@ -188,6 +188,24 @@ Template.sources_show_format_page.events({
       streams: streamChain,
     });
   },
+  'click .add-import-flow'() {
+    const source = getSource();
+    const importFlowsCount = source.getImportFlows().count();
+    const newFlowIndex = importFlowsCount + 1;
+    const newImportFlowName = `Flow_${newFlowIndex}`;
+
+    ImportFlows.insert({
+      sourceId: source._id,
+      name: newImportFlowName,
+      createdAt: Date.now(),
+    });
+
+    const newFlowPath = FlowRouter.path('sources.show.format.for_import_flow', {
+      _id: FlowRouter.getParam('_id'),
+      import_flow_index: newFlowIndex,
+    });
+    FlowRouter.go(newFlowPath);
+  },
   'click .js-start-import'(event) {
     const importFlowId = helpers.currentImportFlow()._id;
     event.preventDefault();

--- a/client/pages/sources/show/format/format.less
+++ b/client/pages/sources/show/format/format.less
@@ -19,12 +19,15 @@
       display: inline-block;
       padding: 6px;
 
+      a {
+        outline: none;
+      }
+
       &.current-import-flow-tab {
         background-color: @color-code-area;
       }
     }
   }
-
 
   .import-flow-actions {
     font-size: 24px;

--- a/client/pages/sources/show/format/format.less
+++ b/client/pages/sources/show/format/format.less
@@ -152,6 +152,7 @@
 
       > section.stream-chain {
         flex: 1;
+
         textarea {
           height: 100%;
           min-height: inherit;
@@ -161,6 +162,31 @@
           background-color: @color-code-area;
           overflow: scroll;
           white-space: pre;
+        }
+
+        .import-flow-errors {
+          transition: 0.3s;
+          right: 0;
+
+          position: fixed;
+          bottom: 0;
+          width: 100%;
+
+          padding: 1em;
+          background-color: white;
+          color: @color-error;
+          font-family: monospace;
+          font-size:14px;
+          ul {
+            li {
+              margin-left: 2em;
+              margin-bottom:5px;
+            }
+          }
+          &.is-empty {
+            transition: 0.3s;
+            right: 100vw;
+          }
         }
       }
     }
@@ -186,23 +212,6 @@
       }
       p:not(:last-child) {
         margin-bottom: 0.5em;
-      }
-      ul.errors {
-        padding: 1em;
-        margin-bottom: 1em;
-        background-color: white;
-        color: @color-error;
-        font-family: monospace;
-        font-size:14px;
-        ul {
-          li {
-            margin-left: 2em;
-            margin-bottom:5px;
-          }
-        }
-        &.is-empty {
-          display: none;
-        }
       }
     }
   }

--- a/client/pages/sources/show/format/format.less
+++ b/client/pages/sources/show/format/format.less
@@ -27,6 +27,19 @@
         background-color: @color-code-area;
       }
     }
+
+    .add-import-flow {
+      background-color: transparent;
+      font-family: 'iconfield';
+
+      padding: 1px 3px;
+      height: 20px;
+      opacity: 0.2;
+
+      &:hover {
+        opacity: 0.5;
+      }
+    }
   }
 
   .import-flow-actions {

--- a/client/pages/sources/show/format/format.less
+++ b/client/pages/sources/show/format/format.less
@@ -19,12 +19,25 @@
       display: inline-block;
       padding: 6px;
 
+      border-right: 1px solid #ccc;
+
       a {
         outline: none;
       }
 
       &.current-import-flow-tab {
         background-color: @color-code-area;
+      }
+
+      .delete-import-flow-icon {
+        background-color: transparent;
+        font-family: 'iconfield';
+        opacity: 0.2;
+        margin-left: 3px;
+
+        &:hover {
+          opacity: 0.5;
+        }
       }
     }
 

--- a/client/pages/sources/show/format/format.less
+++ b/client/pages/sources/show/format/format.less
@@ -14,6 +14,114 @@
     }
   }
 
+  .source-import-flows-tabs {
+    li {
+      display: inline-block;
+      padding: 6px;
+
+      &.current-import-flow-tab {
+        background-color: @color-code-area;
+      }
+    }
+  }
+
+
+  .import-flow-actions {
+    font-size: 24px;
+    font-family: "iconfield";
+    text-align: right;
+
+    button,
+    .import-flow-file-uploader-wrapper,
+    .import-flow-help-wrapper,
+    .import-flow-notifications-wrapper {
+      width: 30px;
+      color: @color-text;
+    }
+
+    button {
+      background-color: transparent;
+    }
+
+    .import-flow-help-wrapper {
+      position: relative;
+      display: inline-block;
+
+      .import-flow-help {
+        text-align: left;
+        position: absolute;
+        display: none;
+        font-family: 'sourcesanspro-regular';
+        width: 450px;
+        right: 0;
+        background: white;
+        border-radius: 5px;
+        padding: 15px;
+        z-index: 10;
+
+        p {
+          margin-top: 0;
+        }
+
+        .iconfont {
+          font-family: 'iconfield';
+        }
+      }
+
+      &:hover {
+        .import-flow-help {
+          display: block;
+        }
+      }
+    }
+
+    .import-flow-notifications-wrapper {
+      position: relative;
+      display: inline-block;
+
+      .import-flow-notifications {
+        text-align: left;
+        position: absolute;
+        display: none;
+        font-family: 'sourcesanspro-regular';
+        width: 450px;
+        right: 0;
+        background: white;
+        border-radius: 5px;
+        padding: 15px;
+        z-index: 10;
+
+        p {
+          margin-top: 0;
+        }
+      }
+  
+      &:hover {
+        .import-flow-notifications {
+          display: block;
+        }
+      }
+    }
+
+    .import-flow-file-uploader-wrapper {
+      height: 20px;
+      width: 26px;
+      overflow: hidden;
+      position: relative;
+      display: inline-block;
+      cursor: pointer;
+
+      .import-flow-file-uploader {
+        cursor: pointer;
+        height: 100%;
+        position:absolute;
+        top: 0;
+        right: 0;
+        opacity: 0;
+      }
+    }
+  }
+
   > section {
     height: 100%;
 

--- a/client/pages/sources/show/format/help.html
+++ b/client/pages/sources/show/format/help.html
@@ -1,0 +1,24 @@
+<template name="import_flow_help">
+  <p>
+    The JSON block on the left defines where your data comes from and how it is formatted:
+  </p>
+
+  <p>
+    You can find more information and examples in
+    <a href='https://github.com/sozialhelden/accessibility-cloud/blob/master/docs/importing-data.md'>our documentation</a>.
+  </p>
+
+  <p>
+    If you feel lost, we are eager to help you! Just <a href='mailto:support@accessibility.cloud'>write us an email</a> and we will help you get started.
+  </p>
+
+  <p>
+    Click on the Start Button (<span class="iconfont">&#x31;</span>) to test
+    if your flow works and get debug information.
+  </p>
+
+  <p>
+    If you don't have an API, you can also upload a JSON or CSV file by clicking
+    on the Upload Button (<span class="iconfont">&#xE815;</span>).
+  </p>
+</template>

--- a/client/pages/sources/show/header/show-header-sub.html
+++ b/client/pages/sources/show/header/show-header-sub.html
@@ -7,7 +7,7 @@
     {{#if source.isEditableBy currentUser._id}}
       <a href='{{pathFor "sources.show.format" _id=source._id}}'
          class='{{activeIfRouteNameIs "sources.show.format"}}'>
-        Import Flow
+        Import Flows
       </a>
       <a href='{{pathFor "sources.show.imports" _id=source._id}}'
          class='{{activeIfRouteNameStartsWith "sources.show.import"}}'>

--- a/client/pages/sources/show/source-imports/imports.js
+++ b/client/pages/sources/show/source-imports/imports.js
@@ -1,11 +1,8 @@
-import { Meteor } from 'meteor/meteor';
 import { Template } from 'meteor/templating';
 import { FlowRouter } from 'meteor/kadira:flow-router';
 import { Sources } from '/both/api/sources/sources.js';
 import { SourceImports } from '/both/api/source-imports/source-imports.js';
 import { PlaceInfos } from '/both/api/place-infos/place-infos.js';
-
-
 import subsManager from '/client/lib/subs-manager';
 
 Template.sources_show_imports_page.onCreated(() => {

--- a/client/pages/sources/show/source-imports/imports.js
+++ b/client/pages/sources/show/source-imports/imports.js
@@ -28,23 +28,6 @@ Template.sources_show_header.helpers({
   },
 });
 
-Template.sources_show_imports_page.events({
-  'click .btn.js-start-import'(event) {
-    event.preventDefault();
-
-    Meteor.call('sources.startImport', FlowRouter.getParam('_id'), (err, result) => {
-      if (err) {
-        console.log(err);
-      } else {
-        FlowRouter.go('sources.show.imports', {
-          _id: FlowRouter.getParam('_id'),
-          importId: result,
-        });
-      }
-    });
-  },
-});
-
 function getCurrentSource() {
   return Sources.findOne(FlowRouter.getParam('_id'));
 }

--- a/client/pages/sources/stream-chain/import_results.html
+++ b/client/pages/sources/stream-chain/import_results.html
@@ -1,0 +1,98 @@
+<template name="import_results">
+  <h2>Import results from {{humanReadableStartTimestamp}}</h2>
+
+  <p class='subtle'>
+
+    {{#if upsertStream}}
+      {{#if isFinished}}
+        {{insertedPlaceInfoCount}} places imported, {{updatedPlaceInfoCount}} updated.
+      {{/if}}
+    {{else}}
+      This import is missing an <code>UpsertPlace</code> stream unit.
+    {{/if}}
+  </p>
+
+  {{#if error}}
+    <p class='error'>Error while importing: {{error.reason}} {{error.message}}</p>
+  {{/if}}
+
+  <ol>
+    {{#each streamChain}}
+      <li class='item {{#if progress.hasError}}has-error{{/if}} {{#if progress.isFinished}}is-finished{{/if}} {{#if skip}}is-skipped{{/if}} {{#if progress.isAborted}}is-aborted{{/if}}'>
+        <div class='progress-bar' style='width: {{progress.percentage}}%'></div>
+
+        {{#with progress}}
+          <aside class='progress' title='{{#if runtime}}after {{humanizedRuntime}} ({{speedString}}){{/if}}'>
+            {{#if ../isSkipped}}
+              skipped
+            {{else}}
+              {{progressString}}
+
+              {{#if isFinished}}
+                <span class='checkmark'>✓</span>
+              {{else}}
+                {{#if eta}}
+                  ({{humanizedEta}} left)
+                {{/if}}
+              {{/if}}
+            {{/if}}
+          </aside>
+        {{/with}}
+
+        <header class='name'>
+          <a href='https://github.com/sozialhelden/accessibility-cloud/blob/master/docs/importing-data.md#{{lowercase type}}'>{{camelize type}}</a>
+          {{#if error}} — {{error.message}}{{/if}} {{#if progress.isAborted}}— aborted{{/if}}
+        </header>
+
+        <section class='comment'>
+          {{#markdown}}{{comment}}{{/markdown}}
+        </section>
+
+        {{#if hasParameters}}
+          <dl class='parameters'>
+            {{#each keyValue parameters}}
+              <dt>{{humanize key}}</dt>
+              <dd>{{stringify value}}</dd>
+            {{/each}}
+          </dl>
+        {{/if}}
+
+        <section class='additional'>
+          {{> Template.dynamic template=additionalTemplate data=this}}
+        </section>
+
+        {{#with error}}
+          <pre class='code-block error'>{{stack}}</pre>
+        {{/with}}
+
+        {{#with debugInfo}}
+          <dl class='debug-info'>
+            {{#each keyValue this}}
+            <dt>
+              {{humanize key}}
+            </dt>
+            <dd>
+              <div class='code-block debug-info'>{{#if isInspectString key}}{{value}}{{else}}{{stringify value}}{{/if}}</div>
+            </dd>
+            {{/each}}
+          </dl>
+        {{/with}}
+
+        <!-- {{#with progress}}
+          <dl class='debug-info'>
+            {{#each keyValue this}}
+            <dt>
+              {{humanize key}}
+            </dt>
+            <dd>
+              <div class='code-block debug-info'>{{#if isInspectString key}}{{value}}{{else}}{{stringify value}}{{/if}}</div>
+            </dd>
+            {{/each}}
+          </dl>
+        {{/with}} -->
+      </li>
+    {{else}}
+      <span class='placeholder'>No input stream defined</span>
+    {{/each}}
+  </ol>
+</template>

--- a/client/pages/sources/stream-chain/stream-chain.html
+++ b/client/pages/sources/stream-chain/stream-chain.html
@@ -1,106 +1,15 @@
 <template name="sources_stream_chain">
   <div class="stream-chain">
-    {{#if getSource.hasRunningImport}}
-      <aside class="actions">
-        <button class='btn btn-danger js-abort-import'>Abort</button>
-      </aside>
+    {{#if source.hasRunningImport}}
+      {{#unless hideAbortButton}}
+        <aside class="actions">
+          <button class='btn btn-danger js-abort-import'>Abort</button>
+        </aside>
+      {{/unless}}
     {{/if}}
 
-    <h2>Import results from {{humanReadableStartTimestamp}}</h2>
-
-    <p class='subtle'>
-
-      {{#if upsertStream}}
-        {{#if isFinished}}
-          {{insertedPlaceInfoCount}} places imported, {{updatedPlaceInfoCount}} updated.
-        {{/if}}
-      {{else}}
-        This import is missing an <code>UpsertPlace</code> stream unit.
-      {{/if}}
-    </p>
-
-    {{#if error}}
-      <p class='error'>Error while importing: {{error.reason}} {{error.message}}</p>
-    {{/if}}
-
-    <ol>
-      {{#each streamChain}}
-        <li class='item {{#if progress.hasError}}has-error{{/if}} {{#if progress.isFinished}}is-finished{{/if}} {{#if skip}}is-skipped{{/if}} {{#if progress.isAborted}}is-aborted{{/if}}'>
-          <div class='progress-bar' style='width: {{progress.percentage}}%'></div>
-
-          {{#with progress}}
-            <aside class='progress' title='{{#if runtime}}after {{humanizedRuntime}} ({{speedString}}){{/if}}'>
-              {{#if ../isSkipped}}
-                skipped
-              {{else}}
-                {{progressString}}
-
-                {{#if isFinished}}
-                  <span class='checkmark'>✓</span>
-                {{else}}
-                  {{#if eta}}
-                    ({{humanizedEta}} left)
-                  {{/if}}
-                {{/if}}
-              {{/if}}
-            </aside>
-          {{/with}}
-
-          <header class='name'>
-            <a href='https://github.com/sozialhelden/accessibility-cloud/blob/master/docs/importing-data.md#{{lowercase type}}'>{{camelize type}}</a>
-            {{#if error}} — {{error.message}}{{/if}} {{#if progress.isAborted}}— aborted{{/if}}
-          </header>
-
-          <section class='comment'>
-            {{#markdown}}{{comment}}{{/markdown}}
-          </section>
-
-          {{#if hasParameters}}
-            <dl class='parameters'>
-              {{#each keyValue parameters}}
-                <dt>{{humanize key}}</dt>
-                <dd>{{stringify value}}</dd>
-              {{/each}}
-            </dl>
-          {{/if}}
-
-          <section class='additional'>
-            {{> Template.dynamic template=additionalTemplate data=this}}
-          </section>
-
-          {{#with error}}
-            <pre class='code-block error'>{{stack}}</pre>
-          {{/with}}
-
-          {{#with debugInfo}}
-            <dl class='debug-info'>
-              {{#each keyValue this}}
-              <dt>
-                {{humanize key}}
-              </dt>
-              <dd>
-                <div class='code-block debug-info'>{{#if isInspectString key}}{{value}}{{else}}{{stringify value}}{{/if}}</div>
-              </dd>
-              {{/each}}
-            </dl>
-          {{/with}}
-
-          <!-- {{#with progress}}
-            <dl class='debug-info'>
-              {{#each keyValue this}}
-              <dt>
-                {{humanize key}}
-              </dt>
-              <dd>
-                <div class='code-block debug-info'>{{#if isInspectString key}}{{value}}{{else}}{{stringify value}}{{/if}}</div>
-              </dd>
-              {{/each}}
-            </dl>
-          {{/with}} -->
-        </li>
-      {{else}}
-        <span class='placeholder'>No input stream defined</span>
-      {{/each}}
-    </ol>
+    {{#with source.getLastSourceImport}}
+      {{> import_results}}
+    {{/with}}
   </div>
 </template>

--- a/client/pages/sources/stream-chain/stream-chain.js
+++ b/client/pages/sources/stream-chain/stream-chain.js
@@ -10,8 +10,7 @@ function format(n) {
   }
   return number.toString();
 }
-
-Template.sources_stream_chain.helpers({
+const helpers = {
   unitName() {
     return this.unitName || 'bytes';
   },
@@ -52,7 +51,10 @@ Template.sources_stream_chain.helpers({
     }
     return `${format(transferred)} ${this.unitName}`;
   },
-});
+};
+
+Template.sources_stream_chain.helpers(helpers);
+Template.import_results.helpers(helpers);
 
 Template.sources_stream_chain.events({
   'click .btn.js-abort-import'(event) {

--- a/client/routes.js
+++ b/client/routes.js
@@ -296,8 +296,22 @@ dataRoutes.route('/organizations/:_id/sources/create', {
   },
 });
 
+// this is the index of the default import flow, always present
+const FIRST_IMPORT_FLOW_INDEX = 1;
+
 dataRoutes.route('/sources/:_id/format', {
   name: 'sources.show.format',
+  title: 'Format',
+  triggersEnter: [(context, redirect) => {
+    redirect(`${context.path}/${FIRST_IMPORT_FLOW_INDEX}`);
+  }],
+  action() {
+    throw new Error('Redirect failed');
+  },
+});
+
+dataRoutes.route('/sources/:_id/format/:import_flow_index', {
+  name: 'sources.show.format.for_import_flow',
   title: 'Format',
   action() {
     BlazeLayout.render('app_layout_full_size', {

--- a/server/migrations.js
+++ b/server/migrations.js
@@ -1,0 +1,29 @@
+/* global Migrations: true */
+
+import { Sources } from '/both/api/sources/sources';
+import { ImportFlows } from '/both/api/import-flows/import-flows';
+
+Migrations.add({
+  version: 1,
+  up() {
+    Sources.find({ streamChain: { $exists: true } }).forEach((source) => {
+      const sourceId = source._id;
+
+      ImportFlows.insert({
+        sourceId,
+        name: 'Default',
+        streams: source.streamChain,
+        createdAt: Date.now()
+      });
+      Sources.update({ _id: sourceId }, { $unset: { streamChain: true } });
+    });
+  },
+  down() {
+    ImportFlows.find({}).forEach((importFlow) => {
+      const sourceId = importFlow.sourceId;
+
+      Sources.update({ _id: sourceId }, { $set: { streamChain: importFlow.streams } });
+      ImportFlows.remove({ _id: importFlow._id });
+    });
+  },
+});

--- a/server/stub-data.js
+++ b/server/stub-data.js
@@ -68,48 +68,6 @@ Factory.define('jsonSource', Sources, {
   primaryRegion: 'Vienna, Austria',
   description: 'All public toilets in vienna (JSON)',
   originWebsiteURL: 'http://data.wien.gv.at',
-  streamChain: [
-    {
-      type: 'HTTPDownload',
-      parameters: {
-        sourceUrl: 'http://data.wien.gv.at/daten/geo?service=WFS&request=GetFeature&version=1.1.0&typeName=ogdwien:WCANLAGEOGD&srsName=EPSG:4326&outputFormat=json',
-      },
-    },
-    {
-      type: 'ConvertToUTF8',
-      parameters: {
-        fromCharSet: 'utf8',
-      },
-    },
-    {
-      type: 'ParseJSONStream',
-      parameters: {
-        path: 'features.*',
-        length: 'totalFeatures',
-      },
-    },
-    {
-      type: 'TransformData',
-      parameters: {
-        mappings: {
-          originalId: 'row.id',
-          geometry: 'row.geometry',
-          category: 'toilets',
-          properties: 'row.properties',
-          address: 'row.properties[\'STRASSE\'] + \', Bezirk \' + row.properties[\'BEZIRK\'] + \', Vienna, Austria\'',
-          'properties-accessibility-withWheelchair': 'row.properties[\'KATEGORIE\'].includes(\'Behindertenkabine\')',
-        },
-      },
-    },
-    {
-      type: 'ConsoleOutput',
-      parameters: {},
-    },
-    {
-      type: 'UpsertPlace',
-      parameters: {},
-    },
-  ],
 });
 
 Factory.define('jsonSourceImport', SourceImports, {
@@ -177,54 +135,6 @@ Factory.define('csvSource', Sources, {
   name: 'Toilets in Rostock (CSV)',
   description: 'germany-rostock-toilets (CSV)',
   originWebsiteURL: 'https://geo.sv.rostock.de/download/opendata/toiletten/',
-  streamChain: [
-    {
-      type: 'HTTPDownload',
-      parameters: {
-        sourceUrl: 'https://geo.sv.rostock.de/download/opendata/toiletten/toiletten.csv',
-      },
-    },
-    {
-      type: 'ConvertToUTF8',
-      parameters: {
-        fromCharSet: 'utf8',
-      },
-    },
-    {
-      type: 'ParseCSVStream',
-      parameters: {
-        header: true,
-      },
-    },
-    {
-      type: 'ParseJSONStream',
-      parameters: {
-        path: '*',
-      },
-    },
-    {
-      type: 'TransformData',
-      parameters: {
-        mappings: {
-          originalId: "row['uuid']",
-          category: 'toilets',
-          geometry: "{ type: 'Point', coordinates: [Number(row['longitude']), Number(row['latitude'])] }",
-          name: "'Public toilet in Rostock, ' + row['gemeindeteil_name']",
-          address: "row['strasse_name'] + ' ' + row['hausnummer'] + row['hausnummer_zusatz'] + ', ' + row['postleitzahl'] + ' Rostock'",
-          'properties-accessibility-withWheelchair': "row['behindertengerecht'] == '1'",
-          properties: 'row.properties',
-        },
-      },
-    },
-    // {
-    //   type: 'ConsoleOutput',
-    //   parameters: {},
-    // },
-    {
-      type: 'UpsertPlace',
-      parameters: {},
-    },
-  ],
 });
 
 Factory.define('csvSourceImport', SourceImports, {


### PR DESCRIPTION
This PR lays the initial groundwork for supporting periodical re-imports of data sources.
Whereas sources used to have a single `streamChain`, they now have multiple `ImportFlows` - which have their own collection.

Other UI changes:
* help text moved to a help icon
* notifications moved to a "warning" icon
* errors displayed at the bottom of the `<textarea>` (they appear and disappear via a CSS transition)

**Screenshot**
![image](https://cloud.githubusercontent.com/assets/167537/23221576/b9866b5c-f925-11e6-8a06-6e1a740e68e5.png)

**Trello ticket**
https://trello.com/c/HqzLJs1c/101-general-concept-to-slurp-change-sets-of-data-sources

⚠️  **Note** 
This PR contains a migration. Deployment **must include** running `migrateTo('latest')` per  `percolatestudio:meteor-migrations` [docs](https://github.com/percolatestudio/meteor-migrations#basics).