### PR TITLE
Parsing data from reference kobo survey

### DIFF
--- a/both/api/place-infos/server/indexing.js
+++ b/both/api/place-infos/server/indexing.js
@@ -6,7 +6,6 @@ Meteor.startup(() => {
   PlaceInfos._ensureIndex({ 'properties.sourceId': 1 });
   PlaceInfos._ensureIndex({ 'properties.sourceImportId': 1 });
   PlaceInfos._ensureIndex({ 'properties.category': 1 });
-  PlaceInfos._ensureIndex({ 'properties.accessibility': 1 });
   PlaceInfos._ensureIndex({ 'properties.accessibility.accessibleWith.wheelchair': 1 });
   PlaceInfos._ensureIndex({ 'properties.accessibility.partlyAccessibleWith.wheelchair': 1 });
   PlaceInfos._ensureIndex({ 'properties.originalId': 1 });

--- a/both/api/sources/server/stream-chain/stream-chain.js
+++ b/both/api/sources/server/stream-chain/stream-chain.js
@@ -25,6 +25,7 @@ import Limit from './stream-types/limit';
 import ConvertArrayToStream from './stream-types/convert-array-to-stream';
 import ConvertStreamToArray from './stream-types/convert-stream-to-array';
 import TransformData from './stream-types/transform-data';
+import TransformKobo from './stream-types/transform-kobo/transform-kobo';
 import TransformScript from './stream-types/transform-script';
 import UpsertPlace from './stream-types/upsert-place';
 import UpsertDisruption from './stream-types/upsert-disruption';
@@ -50,6 +51,7 @@ const StreamTypes = {
   ParseCSVStream,
   Split,
   TransformData,
+  TransformKobo,
   UpsertPlace,
   UpsertDisruption,
   UpsertEquipment,

--- a/both/api/sources/server/stream-chain/stream-types/transform-data/get-helpers-content.js
+++ b/both/api/sources/server/stream-chain/stream-types/transform-data/get-helpers-content.js
@@ -17,6 +17,8 @@ const AVAILABLE_HELPERS = {
     fetchCategoryFromTags: 'fetch-category-from-tags.js',
   },
 
+  kobo: 'kobo/parse-values.js',
+
   extractNumber: 'extract-number.js',
   convertOSGB36ToWGS84Point: 'convert-osgb36-to-wgs84-point.js',
   convert3LetterLanguageCode: 'convert-3-letter-language-code.js',

--- a/both/api/sources/server/stream-chain/stream-types/transform-data/get-helpers-content.test.js
+++ b/both/api/sources/server/stream-chain/stream-types/transform-data/get-helpers-content.test.js
@@ -47,13 +47,18 @@ describe('getHelpersContent', () => {
       'AXSMaps.guessGeoPoint',
       'OSM.fetchNameFromTags',
       'OSM.fetchCategoryFromTags',
+      'kobo.parseValue',
+      'kobo.parseYesNo',
+      'kobo.parseHasSubObject',
+      'kobo.parseFloatUnit',
+      'kobo.parseIntUnit',
       'extractNumber',
       'md5',
       'convertOSGB36ToWGS84Point',
       'convert3LetterCountryCode',
     ];
 
-    EXPECTED_METHOD_PATHS.forEach(methodPath => {
+    EXPECTED_METHOD_PATHS.forEach((methodPath) => {
       it(`has a ${methodPath} method`, () => {
         assert.isFunction(_.get(helpersObj, methodPath));
       });

--- a/both/api/sources/server/stream-chain/stream-types/transform-data/get-vm-context.js
+++ b/both/api/sources/server/stream-chain/stream-types/transform-data/get-vm-context.js
@@ -16,20 +16,22 @@ const getLibsContent = () =>
     .map(fileName => Assets.getText(`transform-libs/${fileName}`))
     .join(';\n');
 
+
+// prefetch the static content to not load on each new vm creation
+const helpersContent = getHelpersContent();
+const libContent = getLibsContent();
+
 export default function getVMContext() {
   const globalObject = Object.freeze({});
-  const helpersContent = getHelpersContent();
   const categoriesJSON = JSON.stringify(getCategories());
   const helpersSetupScript = `
     'use strict';
-
-    ${getLibsContent()};
+    ${libContent};
     var categoryIdForSynonyms = ${categoriesJSON};
     var helpers = ${helpersContent};
   `;
+
   const context = vm.createContext(globalObject);
-
   vm.runInContext(helpersSetupScript, context);
-
   return context;
 }

--- a/both/api/sources/server/stream-chain/stream-types/transform-kobo/ac-ruleset.ts
+++ b/both/api/sources/server/stream-chain/stream-types/transform-kobo/ac-ruleset.ts
@@ -47,6 +47,7 @@ export const partialWheelmapA11yRuleSet: Rule = {
   $or: [
     {
       'properties.accessibility.entrances.0.stairs.0.count': 1,
+      // TODO define unit
       'properties.accessibility.entrances.0.stairs.0.stepHeight': { $lte: 7.0 },
     },
   ],

--- a/both/api/sources/server/stream-chain/stream-types/transform-kobo/ac-ruleset.ts
+++ b/both/api/sources/server/stream-chain/stream-types/transform-kobo/ac-ruleset.ts
@@ -1,34 +1,17 @@
-import { isMatch, isEqual, entries, get, intersection } from 'lodash';
-import { String } from 'aws-sdk/clients/dlm';
+import { Rule, evaluateRule } from './rating-rules';
 
-// TODO align with ac format when available, add operator support
-export interface Quantity {
-  value: number;
-  unit: string;
-}
+// constants
+export const flatStepHeight = { unit: 'cm', value: 7, operator: '<=' };
 
-// rule types
-
-type Comparable = number | string | Quantity;
-type ExistsValue = { $exists: boolean };
-type LessThan = { $lt: Comparable };
-type LessThanEquals = { $lte: Comparable };
-type GreaterThan = { $gt: Comparable };
-type GreaterThanEquals = { $gte: Comparable };
-type Equals = { $eq: Comparable };
-type NotEquals = { $ne: Comparable };
-type MatchValue = string | number | undefined | null | boolean |
-  ExistsValue | LessThan | LessThanEquals | GreaterThan | GreaterThanEquals | Equals | NotEquals;
-type MatchRule = {
-  [key: string]: MatchValue,
+// TODO put real values in here!
+export const wheelChairWashBasin = {
+  height: { unit: 'cm', operator: '>=', value: 80 },
+  depth: { unit: 'cm', operator: '>=', value: 50 },
 };
-type OrRule = {
-  $or: ReadonlyArray<Rule>,
-};
-export type Rule = OrRule | MatchRule;
 
 // the rules for determining that places are fully accessible
 export const fullWheelchairA11yRuleSet: Rule = {
+  // check that there are no stairs
   $or: [
     {
       'properties.accessibility.entrances.0.hasRemovableRamp': true,
@@ -39,7 +22,11 @@ export const fullWheelchairA11yRuleSet: Rule = {
     {
       'properties.accessibility.entrances.0.stairs': null,
     },
+    {
+      'properties.accessibility.entrances.0.isLevel': true,
+    },
   ],
+  // TODO add more rules for door width etc.
 };
 
 // the rules for determining that places are at least partially accessible, omitting the full rules
@@ -47,142 +34,12 @@ export const partialWheelmapA11yRuleSet: Rule = {
   $or: [
     {
       'properties.accessibility.entrances.0.stairs.0.count': 1,
-      // TODO define unit
-      'properties.accessibility.entrances.0.stairs.0.stepHeight': { $lte: 7.0 },
+      'properties.accessibility.entrances.0.stairs.0.stepHeight':
+        { $lte: { value: 7.0, unit: 'cm' } },
     },
   ],
+  // TODO add more rules for door width etc.
 };
-
-// three valued logic for a11y
-export type RuleEvaluationResult = 'true' | 'false' | 'unknown';
-
-
-// combine multiple rules with a three valued or, with the order of true > false > unknown
-// this does not align with Kleene and Priest logics, but knowing that a rule does not apply
-// is strong enough reason to determine that the or should be fals
-function evaluateOrRule(data: {}, orRule: OrRule): RuleEvaluationResult  {
-  let finalResult: RuleEvaluationResult = 'unknown';
-
-  for (const rule of orRule.$or) {
-    const result = evaluateRule(data, rule);
-
-    if (result === 'true') {
-      return 'true';
-    }
-    // apply no if found
-    if (finalResult === 'unknown') {
-      finalResult = result;
-    }
-  }
-  return finalResult;
-}
-
-// read the value out of a quantity
-function getQuantityValue(a: string | number | Quantity) : number | string {
-  let aValue: number | String = 0;
-  if (typeof a === 'object') {
-    // todo use better conversion in the future
-    const multiplier = a.unit === 'inch' ? 2.54 : 1;
-    aValue = a.value * multiplier;
-  } else {
-    aValue = a;
-  }
-  return aValue;
-}
-
-// the allowed operator types for comparisons
-type Operators = '$eq' | '$lt' | '$lte' | '$gt' | '$gte' | '$ne';
-const allowedOperators: ReadonlyArray<Operators> =
-  Object.freeze(['$eq', '$lt', '$lte', '$gt', '$gte', '$ne'] as Operators[]);
-
-// compare two values using an operator, if they are quantities, read the underlying value
-function compareByOperator(
-    first: Comparable,
-    second: Comparable,
-    operator: Operators = '$eq'): boolean {
-  const a = getQuantityValue(first);
-  const b = getQuantityValue(second);
-  if (operator === '$eq') {
-    return a === b;
-  }
-  if (operator === '$lt') {
-    return a < b;
-  }
-  if (operator === '$lte') {
-    return a <= b;
-  }
-  if (operator === '$gt') {
-    return a > b;
-  }
-  if (operator === '$gte') {
-    return a >= b;
-  }
-  if (operator === '$ne') {
-    return a !== b;
-  }
-  return false;
-}
-
-// checks wether the given data matches the rule
-function evaluateMatchRule(data: {}, rule: MatchRule): RuleEvaluationResult  {
-  let finalResult: RuleEvaluationResult | undefined = undefined;
-  for (const [path, matcher] of entries(rule)) {
-    const fieldData = get(data, path);
-    const isObjectMatch = matcher !== null && typeof matcher === 'object';
-    const isExistsRule = isObjectMatch && matcher.hasOwnProperty('$exists');
-
-    if (typeof fieldData === 'undefined' && !isExistsRule) {
-      // data is missing, we don't know if anything about this rule
-      return 'unknown';
-    }if (isObjectMatch) {
-      let matched = false;
-      const foundOperators = intersection(allowedOperators, Object.keys(matcher)) as Operators[];
-      if (foundOperators.length === 1) {
-        // compare by operator
-        matched = compareByOperator(fieldData, matcher[foundOperators[0]], foundOperators[0]);
-      } else if (isExistsRule) {
-        // custom exists check
-        matched = typeof fieldData !== 'undefined';
-      } else {
-        // match object hierarchy
-        matched = isMatch(fieldData, matcher as object);
-      }
-
-      if (!matched) {
-        // any failed comparision and we fail the whole match
-        return 'false';
-      }
-      if (typeof finalResult === 'undefined') {
-        // mark result as yes, and continue checking
-        finalResult = 'true';
-      }
-    } else {
-      // normal data, do a deep equals
-      const equals = isEqual(fieldData, matcher);
-      if (!equals) {
-        // any failed comparision and we fail the whole match
-        return 'false';
-      }
-      if (typeof finalResult === 'undefined') {
-        // mark result as yes, and continue checking
-        finalResult = 'true';
-      }
-    }
-  }
-  return finalResult || 'unknown';
-}
-
-// evaluates any kind of rule
-export function evaluateRule(data: {}, rule: Rule): RuleEvaluationResult {
-  if (rule.$or) {
-    return evaluateOrRule(data, rule as OrRule);
-  }
-  if (typeof rule === 'object') {
-    return evaluateMatchRule(data, rule as MatchRule);
-  }
-
-  return 'unknown';
-}
 
 export type A11yRating = 'yes' | 'no' | 'partial' | 'unknown';
 

--- a/both/api/sources/server/stream-chain/stream-types/transform-kobo/ac-ruleset.ts
+++ b/both/api/sources/server/stream-chain/stream-types/transform-kobo/ac-ruleset.ts
@@ -1,0 +1,205 @@
+import { isMatch, isEqual, entries, get, intersection } from 'lodash';
+import { String } from 'aws-sdk/clients/dlm';
+
+// TODO align with ac format when available, add operator support
+export interface Quantity {
+  value: number;
+  unit: string;
+}
+
+// rule types
+
+type Comparable = number | string | Quantity;
+type ExistsValue = { $exists: boolean };
+type LessThan = { $lt: Comparable };
+type LessThanEquals = { $lte: Comparable };
+type GreaterThan = { $gt: Comparable };
+type GreaterThanEquals = { $gte: Comparable };
+type Equals = { $eq: Comparable };
+type NotEquals = { $ne: Comparable };
+type MatchValue = string | number | undefined | null | boolean |
+  ExistsValue | LessThan | LessThanEquals | GreaterThan | GreaterThanEquals | Equals | NotEquals;
+type MatchRule = {
+  [key: string]: MatchValue,
+};
+type OrRule = {
+  $or: ReadonlyArray<Rule>,
+};
+export type Rule = OrRule | MatchRule;
+
+// the rules for determining that places are fully accessible
+export const fullWheelchairA11yRuleSet: Rule = {
+  $or: [
+    {
+      'properties.accessibility.entrances.0.hasRemovableRamp': true,
+    },
+    {
+      'properties.accessibility.entrances.0.stairs.0.count': 0,
+    },
+    {
+      'properties.accessibility.entrances.0.stairs': null,
+    },
+  ],
+};
+
+// the rules for determining that places are at least partially accessible, omitting the full rules
+export const partialWheelmapA11yRuleSet: Rule = {
+  $or: [
+    {
+      'properties.accessibility.entrances.0.stairs.0.count': 1,
+      'properties.accessibility.entrances.0.stairs.0.stepHeight': { $lte: 7.0 },
+    },
+  ],
+};
+
+// three valued logic for a11y
+export type RuleEvaluationResult = 'true' | 'false' | 'unknown';
+
+
+// combine multiple rules with a three valued or, with the order of true > false > unknown
+// this does not align with Kleene and Priest logics, but knowing that a rule does not apply
+// is strong enough reason to determine that the or should be fals
+function evaluateOrRule(data: {}, orRule: OrRule): RuleEvaluationResult  {
+  let finalResult: RuleEvaluationResult = 'unknown';
+
+  for (const rule of orRule.$or) {
+    const result = evaluateRule(data, rule);
+
+    if (result === 'true') {
+      return 'true';
+    }
+    // apply no if found
+    if (finalResult === 'unknown') {
+      finalResult = result;
+    }
+  }
+  return finalResult;
+}
+
+// read the value out of a quantity
+function getQuantityValue(a: string | number | Quantity) : number | string {
+  let aValue: number | String = 0;
+  if (typeof a === 'object') {
+    // todo use better conversion in the future
+    const multiplier = a.unit === 'inch' ? 2.54 : 1;
+    aValue = a.value * multiplier;
+  } else {
+    aValue = a;
+  }
+  return aValue;
+}
+
+// the allowed operator types for comparisons
+type Operators = '$eq' | '$lt' | '$lte' | '$gt' | '$gte' | '$ne';
+const allowedOperators: ReadonlyArray<Operators> =
+  Object.freeze(['$eq', '$lt', '$lte', '$gt', '$gte', '$ne'] as Operators[]);
+
+// compare two values using an operator, if they are quantities, read the underlying value
+function compareByOperator(
+    first: Comparable,
+    second: Comparable,
+    operator: Operators = '$eq'): boolean {
+  const a = getQuantityValue(first);
+  const b = getQuantityValue(second);
+  if (operator === '$eq') {
+    return a === b;
+  }
+  if (operator === '$lt') {
+    return a < b;
+  }
+  if (operator === '$lte') {
+    return a <= b;
+  }
+  if (operator === '$gt') {
+    return a > b;
+  }
+  if (operator === '$gte') {
+    return a >= b;
+  }
+  if (operator === '$ne') {
+    return a !== b;
+  }
+  return false;
+}
+
+// checks wether the given data matches the rule
+function evaluateMatchRule(data: {}, rule: MatchRule): RuleEvaluationResult  {
+  let finalResult: RuleEvaluationResult | undefined = undefined;
+  for (const [path, matcher] of entries(rule)) {
+    const fieldData = get(data, path);
+    const isObjectMatch = matcher !== null && typeof matcher === 'object';
+    const isExistsRule = isObjectMatch && matcher.hasOwnProperty('$exists');
+
+    if (typeof fieldData === 'undefined' && !isExistsRule) {
+      // data is missing, we don't know if anything about this rule
+      return 'unknown';
+    }if (isObjectMatch) {
+      let matched = false;
+      const foundOperators = intersection(allowedOperators, Object.keys(matcher)) as Operators[];
+      if (foundOperators.length === 1) {
+        // compare by operator
+        matched = compareByOperator(fieldData, matcher[foundOperators[0]], foundOperators[0]);
+      } else if (isExistsRule) {
+        // custom exists check
+        matched = typeof fieldData !== 'undefined';
+      } else {
+        // match object hierarchy
+        matched = isMatch(fieldData, matcher as object);
+      }
+
+      if (!matched) {
+        // any failed comparision and we fail the whole match
+        return 'false';
+      }
+      if (typeof finalResult === 'undefined') {
+        // mark result as yes, and continue checking
+        finalResult = 'true';
+      }
+    } else {
+      // normal data, do a deep equals
+      const equals = isEqual(fieldData, matcher);
+      if (!equals) {
+        // any failed comparision and we fail the whole match
+        return 'false';
+      }
+      if (typeof finalResult === 'undefined') {
+        // mark result as yes, and continue checking
+        finalResult = 'true';
+      }
+    }
+  }
+  return finalResult || 'unknown';
+}
+
+// evaluates any kind of rule
+export function evaluateRule(data: {}, rule: Rule): RuleEvaluationResult {
+  if (rule.$or) {
+    return evaluateOrRule(data, rule as OrRule);
+  }
+  if (typeof rule === 'object') {
+    return evaluateMatchRule(data, rule as MatchRule);
+  }
+
+  return 'unknown';
+}
+
+export type A11yRating = 'yes' | 'no' | 'partial' | 'unknown';
+
+// Evaluates the wheelchair accessibility using the predefined ac rulesets
+export function evaluateWheelChairA11y(data: {}): A11yRating {
+  const full = evaluateRule(data, fullWheelchairA11yRuleSet);
+  if (full === 'true') {
+    return 'yes';
+  }
+
+  const partial = evaluateRule(data, partialWheelmapA11yRuleSet);
+  if (partial === 'true') {
+    return 'partial';
+  }
+
+  if (full === 'false' || partial === 'false') {
+    return 'no';
+  }
+
+  return 'unknown';
+}

--- a/both/api/sources/server/stream-chain/stream-types/transform-kobo/rating-rules.ts
+++ b/both/api/sources/server/stream-chain/stream-types/transform-kobo/rating-rules.ts
@@ -1,0 +1,157 @@
+import { isMatch, isEqual, entries, get, intersection } from 'lodash';
+
+// TODO align with ac format when available, add operator support
+export interface Quantity {
+  value: number;
+  unit: string;
+}
+
+// rule types
+type Comparable = number | string | Quantity;
+type ExistsValue = { $exists: boolean };
+type LessThan = { $lt: Comparable };
+type LessThanEquals = { $lte: Comparable };
+type GreaterThan = { $gt: Comparable };
+type GreaterThanEquals = { $gte: Comparable };
+type Equals = { $eq: Comparable };
+type NotEquals = { $ne: Comparable };
+type MatchValue = string | number | undefined | null | boolean |
+  ExistsValue | LessThan | LessThanEquals | GreaterThan | GreaterThanEquals | Equals | NotEquals;
+type MatchRule = {
+  [key: string]: MatchValue,
+};
+type OrRule = {
+  $or: ReadonlyArray<Rule>,
+};
+export type Rule = OrRule | MatchRule;
+
+// three valued logic for a11y
+export type RuleEvaluationResult = 'true' | 'false' | 'unknown';
+
+
+// combine multiple rules with a three valued or, with the order of true > false > unknown
+// this does not align with Kleene and Priest logics, but knowing that a rule does not apply
+// is strong enough reason to determine that the or should be fals
+function evaluateOrRule(data: {}, orRule: OrRule): RuleEvaluationResult  {
+  let finalResult: RuleEvaluationResult = 'unknown';
+
+  for (const rule of orRule.$or) {
+    const result = evaluateRule(data, rule);
+
+    if (result === 'true') {
+      return 'true';
+    }
+    // apply no if found
+    if (finalResult === 'unknown') {
+      finalResult = result;
+    }
+  }
+  return finalResult;
+}
+
+// read the value out of a quantity
+function getQuantityValue(a: string | number | Quantity) : number | string {
+  let aValue: number | string = 0;
+  if (typeof a === 'object') {
+    // todo use better conversion in the future
+    const multiplier = a.unit === 'inch' ? 2.54 : 1;
+    aValue = a.value * multiplier;
+  } else {
+    aValue = a;
+  }
+  return aValue;
+}
+
+// the allowed operator types for comparisons
+type Operators = '$eq' | '$lt' | '$lte' | '$gt' | '$gte' | '$ne';
+const allowedOperators: ReadonlyArray<Operators> =
+  Object.freeze(['$eq', '$lt', '$lte', '$gt', '$gte', '$ne'] as Operators[]);
+
+// compare two values using an operator, if they are quantities, read the underlying value
+function compareByOperator(
+    first: Comparable,
+    second: Comparable,
+    operator: Operators = '$eq'): boolean {
+  const a = getQuantityValue(first);
+  const b = getQuantityValue(second);
+  if (operator === '$eq') {
+    return a === b;
+  }
+  if (operator === '$lt') {
+    return a < b;
+  }
+  if (operator === '$lte') {
+    return a <= b;
+  }
+  if (operator === '$gt') {
+    return a > b;
+  }
+  if (operator === '$gte') {
+    return a >= b;
+  }
+  if (operator === '$ne') {
+    return a !== b;
+  }
+  return false;
+}
+
+// checks wether the given data matches the rule
+function evaluateMatchRule(data: {}, rule: MatchRule): RuleEvaluationResult  {
+  let finalResult: RuleEvaluationResult | undefined = undefined;
+  for (const [path, matcher] of entries(rule)) {
+    const fieldData = get(data, path);
+    const isObjectMatch = matcher !== null && typeof matcher === 'object';
+    const isExistsRule = isObjectMatch && matcher.hasOwnProperty('$exists');
+
+    if (typeof fieldData === 'undefined' && !isExistsRule) {
+      // data is missing, we don't know if anything about this rule
+      return 'unknown';
+    }if (isObjectMatch) {
+      let matched = false;
+      const foundOperators = intersection(allowedOperators, Object.keys(matcher)) as Operators[];
+      if (foundOperators.length === 1) {
+        // compare by operator
+        matched = compareByOperator(fieldData, matcher[foundOperators[0]], foundOperators[0]);
+      } else if (isExistsRule) {
+        // custom exists check
+        matched = typeof fieldData !== 'undefined';
+      } else {
+        // match object hierarchy
+        matched = isMatch(fieldData, matcher as object);
+      }
+
+      if (!matched) {
+        // any failed comparision and we fail the whole match
+        return 'false';
+      }
+      if (typeof finalResult === 'undefined') {
+        // mark result as yes, and continue checking
+        finalResult = 'true';
+      }
+    } else {
+      // normal data, do a deep equals
+      const equals = isEqual(fieldData, matcher);
+      if (!equals) {
+        // any failed comparision and we fail the whole match
+        return 'false';
+      }
+      if (typeof finalResult === 'undefined') {
+        // mark result as yes, and continue checking
+        finalResult = 'true';
+      }
+    }
+  }
+  return finalResult || 'unknown';
+}
+
+// evaluates any kind of rule
+export function evaluateRule(data: {}, rule: Rule): RuleEvaluationResult {
+  if (rule.$or) {
+    return evaluateOrRule(data, rule as OrRule);
+  }
+  if (typeof rule === 'object') {
+    return evaluateMatchRule(data, rule as MatchRule);
+  }
+
+  return 'unknown';
+}

--- a/both/api/sources/server/stream-chain/stream-types/transform-kobo/transform-kobo.ts
+++ b/both/api/sources/server/stream-chain/stream-types/transform-kobo/transform-kobo.ts
@@ -1,8 +1,13 @@
 import { set, entries, pickBy, includes } from 'lodash';
 import { SimpleSchema } from 'meteor/aldeed:simple-schema';
-import { evaluateWheelChairA11y, flatStepHeight, wheelChairWashBasin } from './ac-ruleset';
-  
+
 const { Transform } = Npm.require('zstreams');
+
+import {
+  flatStepHeight,
+  wheelChairWashBasin,
+  evaluateWheelmapA11y,
+  evaluateToiletWheelmapA11y } from './wheelmap-a11y-ruleset';
 
 type KoboAttachment = {
   mimetype: string,

--- a/both/api/sources/server/stream-chain/stream-types/transform-kobo/transform-kobo.ts
+++ b/both/api/sources/server/stream-chain/stream-types/transform-kobo/transform-kobo.ts
@@ -1,5 +1,6 @@
 import { set, entries, pickBy } from 'lodash';
 import { SimpleSchema } from 'meteor/aldeed:simple-schema';
+import { evaluateWheelChairA11y } from './ac-ruleset';
   
 const { Transform } = Npm.require('zstreams');
 
@@ -130,7 +131,21 @@ const parse = (data: KoboResult) => {
     }
   }
 
-  // TODO apply a11y ratings
+  // rate place a11y
+  const a11y = evaluateWheelChairA11y(result);
+
+  if (a11y === 'yes') {
+    set(result, 'properties.accessibility.accessibleWith.wheelchair', true);
+    set(result, 'properties.accessibility.partiallyAccessibleWith.wheelchair', true);
+  } else if (a11y === 'partial') {
+    set(result, 'properties.accessibility.accessibleWith.wheelchair', false);
+    set(result, 'properties.accessibility.partiallyAccessibleWith.wheelchair', true);
+  } else if (a11y === 'no') {
+    set(result, 'properties.accessibility.accessibleWith.wheelchair', false);
+    set(result, 'properties.accessibility.partiallyAccessibleWith.wheelchair', false);
+  }
+
+  console.log('evaluateWheelChairA11y', mapping['properties.name'], a11y);
 
   // TODO retrieve attachments
 

--- a/both/api/sources/server/stream-chain/stream-types/transform-kobo/transform-kobo.ts
+++ b/both/api/sources/server/stream-chain/stream-types/transform-kobo/transform-kobo.ts
@@ -308,9 +308,6 @@ const parse = (data: KoboResult) => {
             customizedSetter);
   }
 
-  // tslint:disable-next-line:max-line-length
-  console.log('evaluateWheelChairA11y', { a11y, toiletA11y, name: mapping['properties.name'] }, JSON.stringify(mapping, null, 2));
-
   // TODO retrieve attachments
 
   return result;

--- a/both/api/sources/server/stream-chain/stream-types/transform-kobo/transform-kobo.ts
+++ b/both/api/sources/server/stream-chain/stream-types/transform-kobo/transform-kobo.ts
@@ -1,0 +1,200 @@
+import { set, entries, pickBy } from 'lodash';
+import { SimpleSchema } from 'meteor/aldeed:simple-schema';
+  
+const { Transform } = Npm.require('zstreams');
+
+type KoboAttachment = {
+  mimetype: string,
+  download_url: string,
+  filename: string,
+  instance: number,
+  id: number,
+  xform: number,
+};
+
+type YesNoResult = 'true' | 'false' | 'undefined';
+
+type KoboResult = {
+  _uuid: string,
+  _geolocation: [number, number],
+  _attachments: KoboAttachment[],
+  'outside/category/category_sub': string,
+  'outside/category/category_top': string,
+  'outside/entrance/has_automatic_door': YesNoResult,
+  'outside/entrance/has_door': YesNoResult,
+  'outside/entrance/has_entrance': YesNoResult,
+  'outside/entrance/has_mobile_ramp': YesNoResult,
+  'outside/entrance/has_steps': YesNoResult,
+  'outside/entrance/picture': string,
+  'outside/entrance/steps_count': string,
+  'outside/entrance/steps_height': string,
+  'outside/name': string,
+  'user/user_measuring': 'inch' | 'cm',
+  'user/user_record_type': string,
+};
+
+type FieldTypes = 'yesno' | 'hasSubObject' | 'float' | 'int';
+
+const parseValue = (data: KoboResult, field: string, type: FieldTypes) => {
+  const rawValue = data[field];
+  if (rawValue === null || typeof rawValue === 'undefined') {
+    return rawValue;
+  }
+
+  if (type === 'yesno') {
+    if (rawValue === 'true') {
+      return true;
+    }
+    return (rawValue === 'false' ? false : undefined);
+  }
+
+  if (type === 'hasSubObject') {
+    if (rawValue === 'true') {
+      return {};
+    }
+    return undefined;
+  }
+
+  if (type === 'float') {
+    return parseFloat(rawValue);
+  }
+
+  if (type === 'int') {
+    return parseInt(rawValue, 10);
+  }
+
+  return undefined;
+};
+
+const parseYesNo = (data: KoboResult, field: string) => {
+  return parseValue(data, field, 'yesno');
+};
+
+const parseHasSubObject = (data: KoboResult, field: string) => {
+  parseValue(data, field, 'hasSubObject');
+};
+
+const parseFloatUnit = (
+  data: KoboResult, field: string, unit: string, operator?: string) => {
+  const value = parseValue(data, field, 'float');
+  // remove undefined values
+  const unitValue = pickBy({
+    operator,
+    unit,
+    value,
+  });
+  return (value && !isNaN(value)) ? unitValue : undefined;
+};
+
+const parseIntUnit = (
+  data: KoboResult, field: string, unit: string, operator?: string) => {
+  const value = parseValue(data, field, 'int');
+  // remove undefined values
+  const unitValue = pickBy({
+    operator,
+    unit,
+    value,
+  });
+  return (value && !isNaN(value)) ? unitValue : undefined;
+};
+
+const parse = (data: KoboResult) => {
+  const mapping = {
+    geometry: { coordinates: data._geolocation.reverse(), type: 'Point' },
+    'properties.originalId': data._uuid,
+    'properties.infoPageUrl': null,
+    'properties.originalData': JSON.stringify(data),
+    'properties.name': data['outside/name'],
+    'properties.category':
+      data['outside/category/category_top'] || data['outside/category/category_sub'] || 'undefined',
+    'properties.accessibility.entrances.0':
+      parseHasSubObject(data, 'outside/entrance/has_entrance'),
+    'properties.accessibility.entrances.0.stairs.0':
+      parseHasSubObject(data, 'outside/entrance/has_steps'),
+    'properties.accessibility.entrances.0.stairs.0.count':
+      parseValue(data, 'outside/entrance/steps_count', 'int'),
+    'properties.accessibility.entrances.0.stairs.0.stepHeight':
+      parseFloatUnit(data, 'outside/entrance/steps_height', data['user/user_measuring']),
+    'properties.accessibility.entrances.0.hasRemovableRamp':
+      parseYesNo(data, 'outside/entrance/has_mobile_ramp'),
+    'properties.accessibility.entrances.0.doors.0':
+      parseYesNo(data, 'outside/entrance/has_door'),
+    'properties.accessibility.entrances.0.doors.0.isAutomaticOrAlwaysOpen':
+      parseYesNo(data, 'outside/entrance/has_automatic_door'),
+  };
+
+  const result = {};
+  for (const [key, value] of entries(mapping)) {
+    if (typeof value !== 'undefined') {
+      set(result, key, value);
+    }
+  }
+
+  // TODO apply a11y ratings
+
+  // TODO retrieve attachments
+
+  return result;
+};
+
+// transforms a result from an AC kobo survey to ac format
+export default class TransformKobo {
+  stream: any;
+  source: any;
+
+  lengthListener = (length: number) => this.stream.emit('length', length);
+
+  pipeListener = (source: any) => {
+    this.source = source;
+    source.on('length', this.lengthListener);
+  }
+
+  constructor({
+    onDebugInfo = (data: any) => {},
+  }) {
+
+    this.stream = new Transform({
+      writableObjectMode: true,
+      readableObjectMode: true,
+      transform(data: KoboResult,
+                encoding: string,
+                callback: (error: Error, result?: any) => void) {
+        try {
+          const output = parse(data);
+          callback(null, output);
+        } catch (error) {
+          this.emit('error', error);
+          callback(error);
+        }
+      },
+    });
+
+    this.stream.on('pipe', this.pipeListener);
+    this.stream.unitName = 'objects';
+  }
+
+  dispose() {
+    if (this.stream) {
+      if (this.pipeListener) {
+        this.stream.removeListener('pipe', this.pipeListener);
+      }
+      delete this.stream;
+    }
+    if (this.pipeListener) {
+      delete this.pipeListener;
+    }
+    if (this.source) {
+      if (this.lengthListener) {
+        this.source.removeListener('length', this.lengthListener);
+      }
+      delete this.source;
+    }
+    if (this.lengthListener) {
+      delete this.lengthListener;
+    }
+  }
+
+  static getParameterSchema() {
+    return new SimpleSchema({});
+  }
+}

--- a/both/api/sources/server/stream-chain/stream-types/transform-kobo/wheelmap-a11y-ruleset.ts
+++ b/both/api/sources/server/stream-chain/stream-types/transform-kobo/wheelmap-a11y-ruleset.ts
@@ -10,7 +10,8 @@ export const wheelChairWashBasin = {
 };
 
 // the rules for determining that places are fully accessible
-export const fullWheelchairA11yRuleSet: Rule = {
+// first version only support one entrance / stair
+export const fullWheelmapA11yRuleSet: Rule = {
   // check that there are no stairs
   $or: [
     {
@@ -30,6 +31,7 @@ export const fullWheelchairA11yRuleSet: Rule = {
 };
 
 // the rules for determining that places are at least partially accessible, omitting the full rules
+// first version only support one entrance / stair
 export const partialWheelmapA11yRuleSet: Rule = {
   $or: [
     {
@@ -41,11 +43,22 @@ export const partialWheelmapA11yRuleSet: Rule = {
   // TODO add more rules for door width etc.
 };
 
+// the rules for determining that toilets are fully accessible
+// first version only support one restroom
+export const wheelmapToiletA11yRuleSet: Rule = {
+  'properties.accessibility.restrooms': { $exists: true },
+  'properties.accessibility.restrooms.0': { $exists: true },
+  'properties.accessibility.restrooms.0.toilet': { $exists: true },
+  'properties.accessibility.restrooms.0.entrance.isLevel': true,
+  'properties.accessibility.restrooms.0.washBasin.accessibleWithWheelchair': true,
+  // TODO add more rules for door width etc.
+};
+
 export type A11yRating = 'yes' | 'no' | 'partial' | 'unknown';
 
-// Evaluates the wheelchair accessibility using the predefined ac rulesets
-export function evaluateWheelChairA11y(data: {}): A11yRating {
-  const full = evaluateRule(data, fullWheelchairA11yRuleSet);
+// Evaluates the wheelchair accessibility using the predefined wheelmap rulesets
+export function evaluateWheelmapA11y(data: {}): A11yRating {
+  const full = evaluateRule(data, fullWheelmapA11yRuleSet);
   if (full === 'true') {
     return 'yes';
   }
@@ -56,6 +69,20 @@ export function evaluateWheelChairA11y(data: {}): A11yRating {
   }
 
   if (full === 'false' || partial === 'false') {
+    return 'no';
+  }
+
+  return 'unknown';
+}
+
+// Evaluates the wheelchair accessibility of the toilet using the predefined wheelmap rulesets
+export function evaluateToiletWheelmapA11y(data: {}): A11yRating {
+  const full = evaluateRule(data, wheelmapToiletA11yRuleSet);
+  if (full === 'true') {
+    return 'yes';
+  }
+
+  if (full === 'false') {
     return 'no';
   }
 

--- a/private/transform-helpers/kobo/parse-values.js
+++ b/private/transform-helpers/kobo/parse-values.js
@@ -1,0 +1,63 @@
+
+(() => {
+  const parseValue = (data, field, type) => {
+    const rawValue = data[field];
+    if (rawValue === null || typeof rawValue === 'undefined') {
+      return rawValue;
+    }
+
+    if (type === 'yesno') {
+      if (rawValue === 'true') {
+        return true;
+      }
+      return (rawValue === 'false' ? false : undefined);
+    }
+
+    if (type === 'hasSubObject') {
+      return parseValue(data, field, 'yesno') ? {} : undefined;
+    }
+
+    if (type === 'float') {
+      return parseFloat(rawValue);
+    }
+
+    if (type === 'int') {
+      return parseInt(rawValue, 10);
+    }
+
+    return undefined;
+  };
+
+  const parseYesNo = (data, field) => parseValue(data, field, 'yesno');
+
+  const parseHasSubObject = (data, field) => parseValue(data, field, 'hasSubObject');
+
+  const parseFloatUnit = (data, field, unit, operator) => {
+    const value = parseValue(data, field, 'float');
+    const unitValue = _.pickBy({
+      operator,
+      unit,
+      value,
+    });
+    return (value && !isNaN(value)) ? unitValue : undefined;
+  };
+
+  const parseIntUnit = (data, field, unit, operator) => {
+    const value = parseValue(data, field, 'int');
+    const unitValue = _.pickBy({
+      operator,
+      unit,
+      value,
+    });
+    return (value && !isNaN(value)) ? unitValue : undefined;
+  };
+
+  return {
+    parseValue,
+    parseYesNo,
+    parseHasSubObject,
+    parseFloatUnit,
+    parseIntUnit,
+  };
+// eslint-disable-next-line semi
+})()


### PR DESCRIPTION
## Implementation

- Added `TransformKobo` to ac import flows
- It will automatically map all fields used in the reference survey
  to ac format fields
- Several helpers have been added to ease the kobo json parsing
  The parsing follows a simple system:
  - if an entry is not defined or set to the string `'undefined'`, 
    it will be `undefined` in the result.
    This means information about this field is unknown, eg. `{}` has no fields `toilet`.
  - if an entry is false but the result field is an array or object,
    the result value will be `null`. No fields will be set on such an
    object or entries added into that array (usually the survey will skip all those questions).
    This means a facility is known to be missing, eg. `toilets: null` 
  - the values are converted in to their target type and set on the result
    in all other cases.
- A simple rule-system has been added that can evaluate the a11y of
  a place using flexible rules, similar to mongo selectors.
- Rulesets for partial and full place a11y and full toilet a11y have
  been added according to basic wheelmap rules. These rules can be extended
  in the future.

## References

Kobo survey definition can be found at
 https://kobo.humanitarianresponse.info/#/forms/aAwiGtTtvnLDaYdVB6kavu/landing

A full response can be viewed at (make sure you are logged in)
 https://kc.humanitarianresponse.info/api/v1/data/314475/45881180?format=json

Converted into ac format it will look like this:

```
{
  "_id": "kz4sz2TzDtELsPHX5",
  "geometry": {
    "coordinates": [
      13.390832,
      52.54225
    ],
    "type": "Point"
  },
  "properties": {
    "accessibility": {
      "entrances": [
        {
          "stairs": [
            {
              "count": 1,
              "stepHeight": {
                "unit": "cm",
                "value": 1
              }
            }
          ],
          "hasRemovableRamp": true,
          "doors": [
            {
              "isAutomaticOrAlwaysOpen": true
            }
          ]
        }
      ],
      "restrooms": [
        {
          "entrance": {
            "isLevel": true,
            "door": {
              "width": {
                "unit": "cm",
                "value": 60
              }
            }
          },
          "toilet": {
            "heightOfBase": {
              "unit": "cm",
              "value": 61
            },
            "spaceOnUsersLeftSide": {
              "unit": "cm",
              "value": 64
            },
            "spaceOnUsersRightSide": {
              "unit": "cm",
              "value": 62
            },
            "spaceInFront": {
              "unit": "cm",
              "value": 63
            },
            "hasFoldingHandles": true,
            "foldingHandles": {
              "onUsersLeftSide": true,
              "onUsersRightSide": true
            }
          },
          "washBasin": {
            "accessibleWithWheelchair": true,
            "spaceBelow": {
              "height": {
                "unit": "cm",
                "operator": ">=",
                "value": 80
              },
              "depth": {
                "unit": "cm",
                "operator": ">=",
                "value": 50
              }
            }
          },
          "isAccessibleWithWheelchair": true
        }
      ],
      "accessibleWith": {
        "wheelchair": true
      },
      "partiallyAccessibleWith": {
        "wheelchair": true
      },
      "media": {
        "isLargePrint": true,
        "isAudio": true,
        "isBraille": true
      },
      "animalPolicy": {
        "allowsAnyAnimals": true
      },
      "staff": {
        "isTrainedForDisabilities": true,
        "isTrainedInSigning": true,
        "spokenLanguages": [
          "sgn-SA",
          "sgn-CN",
          "sgn-US",
          "sgn-JP",
          "sgn-ES",
          "sgn-GR",
          "sgn-MY",
          "sgn-ES-CT",
          "sgn-AU"
        ]
      }
    },
    "category": "food",
    "infoPageUrl": null,
    "name": "Galette Complet",
    "originalId": "45881180",
    "sourceId": "AEHN5bwt7ceP3eScK",
    "sourceImportId": "fp5t6ZHcvwSpXYMi7"
  }
}
```