### PR TITLE
Copy kobo attachments for a place

### DIFF
--- a/both/api/images/images.js
+++ b/both/api/images/images.js
@@ -7,6 +7,10 @@ import { PlaceInfos } from '../place-infos/place-infos';
 export const Images = new Mongo.Collection('Images');
 
 Images.schema = new SimpleSchema({
+  originalId: {
+    type: String,
+    optional: true,
+  },
   objectId: {
     type: String,
   },

--- a/both/api/images/server/indexing.js
+++ b/both/api/images/server/indexing.js
@@ -2,6 +2,8 @@ import { Meteor } from 'meteor/meteor';
 import { Images } from '../images';
 
 Meteor.startup(() => {
+  // prevent re-uploading foreign images multiple times
+  Images._ensureIndex({ originalId: 1 });
   // for rest api
   Images._ensureIndex({ objectId: 1, context: 1, isUploadedToS3: 1, moderationRequired: 1 });
   // throttling, filter by ip & order by time

--- a/both/api/images/server/save-upload-from-stream.js
+++ b/both/api/images/server/save-upload-from-stream.js
@@ -44,6 +44,8 @@ export function createImageFromStream(imageStream, { mimeType, context, objectId
     } else if (foundImage) {
       console.log('There is already an image with the originalId', originalId);
       callback(null, foundImage);
+      imageStream.emit('close');
+      imageStream.destroy();
       return;
     }
   }

--- a/both/api/sources/server/stream-chain/stream-chain.js
+++ b/both/api/sources/server/stream-chain/stream-chain.js
@@ -118,6 +118,13 @@ export function createStreamChain({
 
   const source = Sources.findOne(sourceId);
   const lastSuccessfulImport = source.getLastSuccessfulImport();
+  let isAborted = false;
+  const abortFn = () => {
+    if (!isAborted) {
+      isAborted = true;
+      abortImport(sourceId);
+    }
+  };
 
   const result = streamChainConfig.map(({ type, parameters = {}, skip = false }, index) => {
     if (!type) {
@@ -140,14 +147,6 @@ export function createStreamChain({
     const progressKey = `${streamChainElementKey}.progress`;
     const errorKey = `${streamChainElementKey}.error`;
     const skippedKey = `${streamChainElementKey}.isSkipped`;
-
-    let isAborted = false;
-    const abortFn = () => {
-      if (!isAborted) {
-        abortImport(sourceId);
-        isAborted = true;
-      }
-    };
 
     const onProgress = Meteor.bindEnvironment(progress => {
       if (progress.percentage === 100) {

--- a/both/api/sources/server/stream-chain/stream-chain.js
+++ b/both/api/sources/server/stream-chain/stream-chain.js
@@ -26,6 +26,7 @@ import ConvertArrayToStream from './stream-types/convert-array-to-stream';
 import ConvertStreamToArray from './stream-types/convert-stream-to-array';
 import TransformData from './stream-types/transform-data';
 import TransformKobo from './stream-types/transform-kobo/transform-kobo';
+import UploadKoboAttachments from './stream-types/transform-kobo/upload-kobo-attachments';
 import TransformScript from './stream-types/transform-script';
 import UpsertPlace from './stream-types/upsert-place';
 import UpsertDisruption from './stream-types/upsert-disruption';
@@ -52,6 +53,7 @@ const StreamTypes = {
   Split,
   TransformData,
   TransformKobo,
+  UploadKoboAttachments,
   UpsertPlace,
   UpsertDisruption,
   UpsertEquipment,

--- a/both/api/sources/server/stream-chain/stream-types/transform-kobo/transform-kobo.ts
+++ b/both/api/sources/server/stream-chain/stream-types/transform-kobo/transform-kobo.ts
@@ -9,7 +9,7 @@ import {
   evaluateWheelmapA11y,
   evaluateToiletWheelmapA11y } from './wheelmap-a11y-ruleset';
 
-type KoboAttachment = {
+export type KoboAttachment = {
   mimetype: string,
   download_url: string,
   filename: string,
@@ -20,7 +20,7 @@ type KoboAttachment = {
 
 type YesNoResult = 'true' | 'false' | 'undefined';
 
-type KoboResult = {
+export type KoboResult = {
   _id: number,
   _uuid: string,
   _geolocation: [number, number],
@@ -62,7 +62,7 @@ type KoboResult = {
 };
 
 // make keys typesafe to prevent typos
-type KoboKey = keyof KoboResult;
+export type KoboKey = keyof KoboResult;
 
 type FieldTypes = 'yesno' | 'float' | 'int';
 
@@ -251,14 +251,17 @@ const parse = (data: KoboResult) => {
                           'inside/toilet/basin_wheelchair_fits_belows',
                           wheelChairWashBasin,
                           null),
+    // animal policy
     'properties.accessibility.animalPolicy.allowsAnyAnimals':
       parseYesNo(data, 'inquire/are_service_animals_allowed'),
+    // staff
     'properties.accessibility.staff.isTrainedForDisabilities':
       parseYesNo(data, 'inquire/staff_has_disabled_training'),
     'properties.accessibility.staff.spokenLanguages':
       parseMultiSelect(data, 'inquire/staff_spoken_sign_langs'),
     'properties.accessibility.staff.isTrainedInSigning':
       parseYesNo(data, 'inquire/staff_can_speak_sign_lang'),
+    // media
     'properties.accessibility.media.isLargePrint':
       parseYesNo(data, 'inquire/media/has_large_print'),
     'properties.accessibility.media.isAudio':

--- a/both/api/sources/server/stream-chain/stream-types/transform-kobo/upload-kobo-attachments.ts
+++ b/both/api/sources/server/stream-chain/stream-types/transform-kobo/upload-kobo-attachments.ts
@@ -1,0 +1,188 @@
+import * as stream from 'stream';
+import * as request from 'request';
+
+import { SimpleSchema } from 'meteor/aldeed:simple-schema';
+import { KoboKey, KoboResult, KoboAttachment } from './transform-kobo';
+import { createImageFromStream } from '../../../../../images/server/save-upload-from-stream.js';
+import { PlaceInfos } from '../../../../../place-infos/place-infos';
+
+const { Transform } = Npm.require('zstreams');
+
+type InsertedPlace = {
+  properties: {
+    originalId: string;
+    originalData: string;
+  },
+};
+
+type UpsertResult = {
+  doc: InsertedPlace,
+  result: {
+    insertedId?: string,
+  },
+};
+
+const koboBaseUrl = 'https://kc.humanitarianresponse.info';
+
+const imageAttachmentFields: KoboKey[] = [
+  'inside/toilet/toilet_photo',
+  'outside/entrance/picture',
+];
+
+// find all attachments for the allow fields
+function findImageAttachments(data: KoboResult): KoboAttachment[] {
+  const attachments = data._attachments;
+
+  return imageAttachmentFields.map((field) => {
+    const fileName = data[field];
+
+    if (typeof fileName !== 'string') {
+      return null;
+    }
+    return attachments.find(a => a.filename.endsWith(fileName));
+  }).filter(Boolean);
+}
+
+function fetchImages(lastResult: UpsertResult, callback: (error: Error, result?: any) => void) {
+  const { doc: data, result  } = lastResult;
+
+  if (!data || !data.properties || typeof data.properties.originalData !== 'string') {
+    callback(new Error('No data found'), null);
+    return;
+  }
+  // we do not get an _id field on the UpsertResult if it was an update, so we need to query again
+  let objectId = result.insertedId;
+  if (!objectId) {
+    const foundPlace = PlaceInfos.findOne({ 'properties.originalId': data.properties.originalId },
+                                          { transform: null, fields: { } });
+    if (foundPlace) {
+      objectId = foundPlace._id;
+    }
+  }
+
+  if (!objectId) {
+    callback(new Error('No place found'), null);
+    return;
+  }
+
+  const koboData: KoboResult = JSON.parse(data.properties.originalData);
+  const attachments = findImageAttachments(koboData);
+
+  let remainingCallbacksCount = attachments.length;
+  const streams = attachments.map((a) => {
+    const originalId = `${a.instance}:${a.id}`;
+
+    const fileName = encodeURI(a.filename);
+    // sadly the download_url in the kobo attachments will get stale, thus we need to use
+    // an undocumented feature to get the correct forward
+    //   see also https://github.com/kobotoolbox/kpi/issues/1542
+    //   and the implementation in https://github.com/kobotoolbox/kpi/blob/08f06b1c2ce237eac46d0f15e86d44cfc53388a2/jsapp/js/components/submission.es6#L127
+    const downloadUrl = `${koboBaseUrl}/attachment/original?media_file=${fileName}`;
+
+    const imageDownloadStream = new stream.PassThrough();
+    const requestWithRedirect = {
+      followAllRedirects: true,
+      url: downloadUrl,
+      timeout: 15000,
+    };
+    const requestResult = request(requestWithRedirect).pipe(imageDownloadStream);
+
+    const imageAttributes = {
+      originalId,
+      objectId,
+      mimeType: a.mimetype,
+      context: 'place',
+      hashedIp: 'ACIMPORT',
+      appToken: 'ACIMPORT',
+    };
+    createImageFromStream(imageDownloadStream, imageAttributes, (error, result) => {
+      remainingCallbacksCount -= 1;
+      if (remainingCallbacksCount <= 0) {
+        callback(null, null);
+      }
+    });
+
+    imageDownloadStream.on('abort', () => {
+      requestResult.abort();
+    });
+
+    return requestResult;
+  });
+
+  if (streams.length === 0) {
+    callback(null, []);
+  }
+
+  return streams;
+}
+
+export default class UploadKoboAttachments {
+  stream: any;
+  source: any;
+
+  lengthListener = (length: number) => this.stream.emit('length', length);
+
+  requests: any[];
+
+  pipeListener = (source: any) => {
+    this.source = source;
+    source.on('length', this.lengthListener);
+  }
+
+  constructor({
+    onDebugInfo = (data: any) => {},
+  }) {
+
+    this.stream = new Transform({
+      writableObjectMode: true,
+      readableObjectMode: true,
+      transform: Meteor.bindEnvironment(
+        (data: UpsertResult,
+         encoding: string,
+         callback: (error: Error, result?: any) => void) => {
+          try {
+            this.requests = fetchImages(data, callback);
+          } catch (error) {
+            callback(error);
+          }
+        }),
+    });
+
+    this.stream.on('pipe', this.pipeListener);
+    this.stream.unitName = 'responses';
+  }
+
+  abort() {
+    if (this.requests) {
+      for (const request of this.requests) {
+        request.abort();
+      }
+      delete this.requests;
+    }
+  }
+
+  dispose() {
+    if (this.stream) {
+      if (this.pipeListener) {
+        this.stream.removeListener('pipe', this.pipeListener);
+      }
+      delete this.stream;
+    }
+    if (this.source) {
+      if (this.lengthListener) {
+        this.source.removeListener('length', this.lengthListener);
+      }
+      delete this.source;
+    }
+    if (this.requests) {
+      for (const request of this.requests) {
+        request.abort();
+      }
+      delete this.requests;
+    }
+  }
+
+  static getParameterSchema() {
+    return new SimpleSchema({});
+  }
+}

--- a/both/api/sources/server/stream-chain/stream-types/upsert.js
+++ b/both/api/sources/server/stream-chain/stream-types/upsert.js
@@ -120,9 +120,10 @@ export default class Upsert {
             } else if (result && result.numberAffected) {
               updatedDocumentCount += 1;
             }
+
             streamObject.afterUpsert(
               { doc: Object.assign({}, postProcessedDoc), organizationSourceIds, organizationName },
-              () => callback(upsertError, result),
+              () => callback(upsertError, { doc: postProcessedDoc, result }),
             );
           });
         } catch (caughtError) {


### PR DESCRIPTION
- Finds all attachments in the previous stream upsert results
- Resolves the correct attachment url
- Passes the download stream into the image upload
  stream also used for the post api
- Added feature to prevent retrying already finished uploads
  with the same id
- Depends on #59, 'Parsing data from reference kobo survey'