### PR TITLE
Extend Kobo import

### DIFF
--- a/both/api/sources/server/stream-chain/stream-types/transform-kobo/rating-rules.ts
+++ b/both/api/sources/server/stream-chain/stream-types/transform-kobo/rating-rules.ts
@@ -49,7 +49,7 @@ export type RuleEvaluationResult = 'true' | 'false' | 'unknown';
 
 // combine multiple rules with a three valued or, with the order of true > false > unknown
 // this does not align with Kleene and Priest logics, but knowing that a rule does not apply
-// is strong enough reason to determine that the or should be fals
+// is strong enough reason to determine that the or should be false
 function evaluateOrRule(data: {}, orRule: OrRule): RuleEvaluationResult  {
   let finalResult: RuleEvaluationResult = 'unknown';
 

--- a/both/api/sources/server/stream-chain/stream-types/transform-kobo/transform-kobo.ts
+++ b/both/api/sources/server/stream-chain/stream-types/transform-kobo/transform-kobo.ts
@@ -283,15 +283,16 @@ const parse = (data: KoboResult) => {
   const a11y = evaluateWheelmapA11y(result);
 
   // TODO these fields don't exist in ac format! Clarify & align with wheelmap frontend & ac-format
+  // Currently, these fields are exlusive.
   if (a11y === 'yes') {
     set(result, 'properties.accessibility.accessibleWith.wheelchair', true);
-    set(result, 'properties.accessibility.partiallyAccessibleWith.wheelchair', true);
+    set(result, 'properties.accessibility.partiallyAccessibleWith.wheelchair', null);
   } else if (a11y === 'partial') {
     set(result, 'properties.accessibility.accessibleWith.wheelchair', false);
     set(result, 'properties.accessibility.partiallyAccessibleWith.wheelchair', true);
   } else if (a11y === 'no') {
     set(result, 'properties.accessibility.accessibleWith.wheelchair', false);
-    set(result, 'properties.accessibility.partiallyAccessibleWith.wheelchair', false);
+    set(result, 'properties.accessibility.partiallyAccessibleWith.wheelchair', null);
   }
 
   // rate place a11y

--- a/both/api/sources/server/stream-chain/stream-types/transform-kobo/wheelmap-a11y-ruleset.ts
+++ b/both/api/sources/server/stream-chain/stream-types/transform-kobo/wheelmap-a11y-ruleset.ts
@@ -12,19 +12,30 @@ export const wheelChairWashBasin = {
 // the rules for determining that places are fully accessible
 // first version only support one entrance / stair
 export const fullWheelmapA11yRuleSet: Rule = {
-  // check that there are no stairs
-  $or: [
+  $and: [
+    // survey responder thought the place was fully wheelchair accessible
     {
-      'properties.accessibility.entrances.0.hasRemovableRamp': true,
+      'properties.accessibility.accessibleWith.wheelchair': true,
     },
+    // check that there are no stairs
     {
-      'properties.accessibility.entrances.0.stairs.0.count': 0,
-    },
-    {
-      'properties.accessibility.entrances.0.stairs': null,
-    },
-    {
-      'properties.accessibility.entrances.0.isLevel': true,
+      $or: [
+        {
+          'properties.accessibility.entrances.0.hasFixedRamp': true,
+        },
+        {
+          'properties.accessibility.entrances.0.hasRemovableRamp': true,
+        },
+        {
+          'properties.accessibility.entrances.0.stairs.0.count': 0,
+        },
+        {
+          'properties.accessibility.entrances.0.stairs': null,
+        },
+        {
+          'properties.accessibility.entrances.0.isLevel': true,
+        },
+      ],
     },
   ],
   // TODO add more rules for door width etc.
@@ -33,7 +44,17 @@ export const fullWheelmapA11yRuleSet: Rule = {
 // the rules for determining that places are at least partially accessible, omitting the full rules
 // first version only support one entrance / stair
 export const partialWheelmapA11yRuleSet: Rule = {
-  $or: [
+  $and: [
+    {
+      $or: [
+        {
+          'properties.accessibility.accessibleWith.wheelchair': true,
+        },
+        {
+          'properties.accessibility.partiallyAccessibleWith.wheelchair': true,
+        },
+      ],
+    },
     {
       'properties.accessibility.entrances.0.stairs.0.count': 1,
       'properties.accessibility.entrances.0.stairs.0.stepHeight':


### PR DESCRIPTION
- Move `removeNullAndUndefinedFields` to its own file
- Fix broken URL last-import-date insertion
- Fix global stats generation
- Cleanup undefined and null values from Kobo imports
- Make partial and full accessibility booleans mutually exclusive
- Add support for `$and` rules for a11y rating
- Support more fields in Kobo import
- Change wheelchair a11y calculation logic in Kobo importer
