### PR TITLE
Record equipment status

### DIFF
--- a/both/api/equipment-status-reports/server/update-equipment.js
+++ b/both/api/equipment-status-reports/server/update-equipment.js
@@ -1,6 +1,5 @@
 import set from 'lodash/set';
 import { EquipmentInfos } from '../../equipment-infos/equipment-infos';
-import { PlaceInfos } from '../../place-infos/place-infos';
 import { EquipmentStatusReports } from '../equipment-status-reports';
 import sendPurgeRequestToFastly from '../../../../server/cdn-purging/sendPurgeRequestToFastly';
 import isEmpty from 'lodash/isEmpty';
@@ -37,23 +36,7 @@ export default function updateEquipmentWithStatusReport(report) {
   console.log('Updating equipment', id, modifier);
   if (!isEmpty(modifier)) {
     EquipmentInfos.update(id, modifier);
-    const equipmentInfo = EquipmentInfos.findOne(id, { transform: null, fields: { statusReportToken: false, 'properties.originalData': false } });
-    if (!equipmentInfo) return;
-    if (!equipmentInfo.properties) return;
-    if (!equipmentInfo.properties.placeInfoId) return;
-    const placeInfoId = equipmentInfo.properties.placeInfoId;
-    const cacheUpdateModifier = {
-      $set: {
-        [`properties.equipmentInfos.${equipmentInfo._id}`]: equipmentInfo,
-      },
-    };
-    if (typeof equipmentInfo.properties.isWorking === 'undefined') {
-      cacheUpdateModifier.$unset = {
-        [`properties.equipmentInfos.${equipmentInfo._id}.properties.isWorking`]: true,
-      };
-    }
-    PlaceInfos.update(placeInfoId, cacheUpdateModifier);
-    sendPurgeRequestToFastly([placeInfoId, equipmentInfo._id]);
+    sendPurgeRequestToFastly([id]);
   }
 }
 

--- a/both/api/equipment-status-samples/equipment-status-samples.js
+++ b/both/api/equipment-status-samples/equipment-status-samples.js
@@ -1,0 +1,52 @@
+import { Meteor } from 'meteor/meteor';
+import { Mongo } from 'meteor/mongo';
+import { SimpleSchema } from 'meteor/aldeed:simple-schema';
+import { EquipmentInfos } from '../equipment-infos/equipment-infos';
+import { Sources } from '../sources/sources';
+import { Organizations } from '../organizations/organizations';
+
+export const EquipmentStatusSamples = new Mongo.Collection('EquipmentStatusSamples');
+
+EquipmentStatusSamples.schema = new SimpleSchema({
+  createdAt: {
+    type: Date,
+  },
+  equipmentInfoOriginalId: {
+    type: String,
+  },
+  isProcessed: {
+    type: Boolean,
+  },
+  isWorking: {
+    type: Boolean,
+  },
+  organizationId: {
+    type: String,
+  },
+  sourceId: {
+    type: String,
+  },
+});
+
+EquipmentStatusSamples.attachSchema(EquipmentStatusSamples.schema);
+
+EquipmentStatusSamples.relationships = {
+  belongsTo: {
+    equipmentInfo: {
+      foreignCollection: EquipmentInfos,
+      foreignKey: 'equipmentInfoId',
+    },
+    source: {
+      foreignCollection: Sources,
+      foreignKey: 'sourceId',
+    },
+    organization: {
+      foreignCollection: Organizations,
+      foreignKey: 'organizationId',
+    },
+  },
+};
+
+if (Meteor.isClient) {
+  window.EquipmentStatusSamples = EquipmentStatusSamples;
+}

--- a/both/api/equipment-status-samples/recordEquipmentStatusSample.ts
+++ b/both/api/equipment-status-samples/recordEquipmentStatusSample.ts
@@ -1,0 +1,22 @@
+import { EquipmentStatusSamples } from './equipment-status-samples';
+import { EquipmentInfo } from '@sozialhelden/a11yjson';
+
+export default function recordEquipmentStatusSample({
+  equipmentInfo,
+  organizationId,
+  sourceId,
+}: {
+  equipmentInfo: EquipmentInfo,
+  organizationId: string,
+  sourceId: string,
+}) {
+  EquipmentStatusSamples.insert({
+    organizationId,
+    sourceId,
+    createdAt: new Date(),
+    equipmentInfoId: equipmentInfo._id,
+    equipmentInfoOriginalId: equipmentInfo.properties.originalId,
+    isProcessed: false,
+    isWorking: equipmentInfo.properties.isWorking,
+  });
+}

--- a/both/api/equipment-status-samples/recordStatusChanges.ts
+++ b/both/api/equipment-status-samples/recordStatusChanges.ts
@@ -35,9 +35,7 @@ export default function recordStatusChanges({
   const ids = changedLightweightEquipmentInfos.map(e => e._id);
   const changedEquipmentInfos = EquipmentInfos.find({ _id: { $in: ids }}).fetch();
   changedEquipmentInfos.forEach(e => {
-    console.log('Recording new equipment status:');
-    console.log(e);
-    // console.log(`Recording new equipment status: ${e._id} / status: ${e.properties.isWorking} / originalId: ${e.properties.originalId} / ‘${e.properties.description}’.`);
+    console.log(`Recording new equipment status: ${e._id} / ${e.properties.isWorking ? '✅' : '🚧'} / originalId: ${e.properties.originalId} / ‘${e.properties.description || e.properties.shortDescription || e.properties.longDescription}’.`);
     recordEquipmentStatusSample({ equipmentInfo: e, organizationId, sourceId });
   });
 

--- a/both/api/equipment-status-samples/recordStatusChanges.ts
+++ b/both/api/equipment-status-samples/recordStatusChanges.ts
@@ -1,0 +1,45 @@
+import { keyBy } from 'lodash';
+import recordEquipmentStatusSample from './recordEquipmentStatusSample';
+import { LightweightEquipmentInfo } from './takeEquipmentSnapshot';
+import { EquipmentInfos } from '../equipment-infos/equipment-infos';
+
+/**
+ * Record changes in `isWorking` attributes for all equipment that changed this property between
+ * two given snapshots
+ */
+
+export default function recordStatusChanges({
+  sourceId,
+  organizationId,
+  equipmentInfosBeforeImport,
+  equipmentInfosAfterImport,
+}: {
+  sourceId: string,
+  organizationId: string,
+  equipmentInfosBeforeImport: LightweightEquipmentInfo[],
+  equipmentInfosAfterImport: LightweightEquipmentInfo[]
+}) {
+  const equipmentInfosAfterImportByOriginalId = keyBy(equipmentInfosAfterImport, e => e.properties.originalId);
+
+  console.log(`Comparing EquipmentInfos in source "${sourceId}".`);
+  console.log(`Before: ${equipmentInfosBeforeImport.length} equipment infos`);
+  console.log(`After: ${Object.keys(equipmentInfosAfterImportByOriginalId).length} equipment infos`);
+  const changedLightweightEquipmentInfos = [];
+
+  for (const before of equipmentInfosBeforeImport) {
+    const after = equipmentInfosAfterImportByOriginalId[before.properties.originalId];
+    if (before.properties.isWorking !== after.properties.isWorking) {
+      changedLightweightEquipmentInfos.push(after);
+    }
+  }
+  const ids = changedLightweightEquipmentInfos.map(e => e._id);
+  const changedEquipmentInfos = EquipmentInfos.find({ _id: { $in: ids }}).fetch();
+  changedEquipmentInfos.forEach(e => {
+    console.log('Recording new equipment status:');
+    console.log(e);
+    // console.log(`Recording new equipment status: ${e._id} / status: ${e.properties.isWorking} / originalId: ${e.properties.originalId} / ‘${e.properties.description}’.`);
+    recordEquipmentStatusSample({ equipmentInfo: e, organizationId, sourceId });
+  });
+
+  console.log(`${changedEquipmentInfos.length} equipment changes recorded.`)
+}

--- a/both/api/equipment-status-samples/takeEquipmentSnapshot.ts
+++ b/both/api/equipment-status-samples/takeEquipmentSnapshot.ts
@@ -1,0 +1,26 @@
+import { EquipmentInfos } from '../equipment-infos/equipment-infos';
+
+export type LightweightEquipmentInfo = {
+  _id?: string;
+  properties: {
+    isWorking: boolean;
+    originalId: string;
+  }
+}
+
+/**
+ * @returns an array of `EquipmentInfo` objects. Each object is stripped, only
+ * `properties.isWorking` and `properties.originalId` attributes are left.
+ */
+export default function takeEquipmentSnapshotForSourceId(sourceId): LightweightEquipmentInfo[] {
+  console.log(`Taking snapshot of all equipment from source ID ${sourceId}.`)
+  const selector = { 'properties.sourceId': sourceId };
+  const options = {
+    transform: null,
+    fields: {
+      'properties.isWorking': 1,
+      'properties.originalId': 1,
+    },
+  };
+  return EquipmentInfos.find(selector, options).fetch();
+}

--- a/both/api/sources/server/stream-chain/stream-types/upsert.js
+++ b/both/api/sources/server/stream-chain/stream-types/upsert.js
@@ -117,7 +117,7 @@ export default class Upsert {
             organizationName,
           });
 
-          console.log('Upserting doc with tile coordinates', doc.tileCoordinates);
+          // console.log('Upserting doc with tile coordinates', doc.tileCoordinates);
 
           // Using flatten here to deep-merge new properties into existing
           streamClass.collection.upsert({

--- a/docs/importing-data.md
+++ b/docs/importing-data.md
@@ -276,6 +276,7 @@ Note that disruptions have a [specific set of attributes](https://github.com/soz
 
 This works like `UpsertPlace`, but using it marks the source as a data source for disruptions, which enables special features:
 
+- Add a `equipmentSourceId` parameter to this stream to refer to an equipment source that should be watched for status changes.
 - A disruption can belong to a `PlaceInfo` or `EquipmentInfo` from another data source. The same way, a place or equipment/facility can have a list of disruptions in the past, present and future. Depending on the imported data model, its your choice if you want to associate a disruption with a place or equipment/facility.
 - If a transformed imported PoI has `properties.originalPlaceInfoId` and `properties.placeSourceId` properties, importing will associate the disruption with the place.
 - If a transformed imported PoI has `properties.originalEquipmentInfoId` and `properties.equipmentSourceId` properties, importing will associate the disruption with the equipment/facility.


### PR DESCRIPTION
This records equipment status changes in `EquipmentInfo` and `DisruptionInfo` data sources. 

When an import 
- upserts a `DisruptionInfo` that changes an `EquipmentInfo`'s `isWorking` attribute
- upserts an `EquipmentInfo` with a changed `isWorking` attribute

this code finds out these changes by making a snapshot before/after the import.

Every time such a change occurs, an `EquipmentStatusSample` database document is inserted to keep track of stats. Another process can then pick up these samples and process them to generate notifications, dashboard charts, …

Side note: The PR also removes caching `EquipmentInfo`s inside `PlaceInfo`s, as the frontend does not need this caching anymore. This reduces the risk of errors with out-of-sync data. If the frontend needs `EquipmentInfo`s, it gets them using the tile API already: As equipment uses less data per tile, it simply fetches/caches bigger tiles.